### PR TITLE
fix: empty crossbell

### DIFF
--- a/service/indexer/internal/datasource/blockscout/datasource.go
+++ b/service/indexer/internal/datasource/blockscout/datasource.go
@@ -146,6 +146,7 @@ func (d *Datasource) handleTokenTransfers(ctx context.Context, message *protocol
 		transfers = append(transfers, model.Transfer{
 			TransactionHash: internalTokenTransfer.Hash,
 			Timestamp:       time.Unix(internalTokenTransfer.TimeStamp.BigInt().Int64(), 0),
+			Metadata:        metadata.Default,
 			Index:           internalTokenTransfer.LogIndex.IntPart(),
 			AddressFrom:     internalTokenTransfer.From,
 			AddressTo:       internalTokenTransfer.To,

--- a/service/indexer/internal/server/server.go
+++ b/service/indexer/internal/server/server.go
@@ -6,8 +6,6 @@ import (
 	"errors"
 	"time"
 
-	"github.com/naturalselectionlabs/pregod/service/indexer/internal/worker/snapshot"
-
 	"github.com/go-redis/redis/v8"
 	_ "github.com/lib/pq"
 	"github.com/naturalselectionlabs/pregod/common/cache"
@@ -30,6 +28,7 @@ import (
 	"github.com/naturalselectionlabs/pregod/service/indexer/internal/worker/gitcoin"
 	"github.com/naturalselectionlabs/pregod/service/indexer/internal/worker/mirror"
 	poapworker "github.com/naturalselectionlabs/pregod/service/indexer/internal/worker/poap"
+	"github.com/naturalselectionlabs/pregod/service/indexer/internal/worker/snapshot"
 	"github.com/naturalselectionlabs/pregod/service/indexer/internal/worker/swap"
 	"github.com/naturalselectionlabs/pregod/service/indexer/internal/worker/token"
 	"github.com/naturalselectionlabs/pregod/service/indexer/internal/worker/token/coinmarketcap"
@@ -125,13 +124,13 @@ func (s *Server) Initialize() (err error) {
 	}
 
 	s.workers = []worker.Worker{
+		crossbell.New(),
 		token.New(s.databaseClient),
 		swap.New(s.employer, s.databaseClient),
 		mirror.New(),
 		poapworker.New(),
 		gitcoin.New(s.databaseClient, s.redisClient),
 		snapshot.New(s.databaseClient, s.redisClient),
-		crossbell.New(),
 	}
 
 	s.employer = shedlock.New(s.redisClient)
@@ -235,6 +234,7 @@ func (s *Server) handle(ctx context.Context, message *protocol.Message) (err err
 			if network == message.Network {
 				internalTransactions, err := worker.Handle(ctx, message, transactions)
 				if err != nil {
+					logrus.Error(worker.Name(), message.Network, err)
 					return err
 				}
 

--- a/service/indexer/internal/worker/snapshot/worker.go
+++ b/service/indexer/internal/worker/snapshot/worker.go
@@ -217,8 +217,9 @@ func (s *service) Handle(ctx context.Context, message *protocol.Message, transac
 			Space:    spaceMetadata,
 			Choice:   vote.Choice,
 		}
+		metadataModel.SnapShot = &snapShotMetadata
 
-		rawMetadata, err := json.Marshal(snapShotMetadata)
+		rawMetadata, err := json.Marshal(metadataModel)
 		if err != nil {
 			logrus.Warnf("[snapshot worker] failed to marshal metadata:%v", err)
 			continue
@@ -236,8 +237,6 @@ func (s *service) Handle(ctx context.Context, message *protocol.Message, transac
 			continue
 		}
 
-		metadataModel.SnapShot = &snapShotMetadata
-
 		relatedUrl := "https://snapshot.org/#/" + vote.SpaceID + "/proposal/" + vote.ProposalID
 		lowerAddress := strings.ToLower(message.Address)
 
@@ -248,7 +247,7 @@ func (s *service) Handle(ctx context.Context, message *protocol.Message, transac
 			Platform:    Name,
 			Network:     message.Network,
 			Source:      s.Name(),
-			SourceData:  rawMetadata,
+			SourceData:  rawSourcedata,
 			Transfers: []model.Transfer{
 				{
 					TransactionHash: vote.ID,

--- a/service/indexer/internal/worker/snapshot/worker.go
+++ b/service/indexer/internal/worker/snapshot/worker.go
@@ -126,10 +126,10 @@ func (s *service) Handle(ctx context.Context, message *protocol.Message, transac
 
 	timeStamp, err := s.getLatestTimestamp(message)
 	if message.Network == "ethereum" {
-		logrus.Infof("this is ethereum, address: %s, timeStamp:", message.Address, timeStamp)
+		logrus.Infof("this is ethereum, address: %s, %s:", message.Address, timeStamp)
 	}
 	if err != nil {
-		logrus.Errorf("failed to get latest timestamp: %w", err)
+		logrus.Errorf("failed to get latest timestamp: %s", err)
 		return nil, err
 	}
 
@@ -138,8 +138,8 @@ func (s *service) Handle(ctx context.Context, message *protocol.Message, transac
 		logrus.Infof("this is ethereum, address: %s, len(votes):%d", message.Address, len(votes))
 	}
 	if err != nil {
-		logrus.Errorf("failed to get snapshot votes: %w", err)
-		return nil, fmt.Errorf("[snapshot worker] failed to get snapshot votes: %w", err)
+		logrus.Errorf("failed to get snapshot votes: %s", err)
+		return nil, fmt.Errorf("[snapshot worker] failed to get snapshot votes: %s", err)
 	}
 	if len(votes) == 0 {
 		return nil, nil
@@ -296,7 +296,7 @@ func (s *service) Jobs() []worker.Job {
 				LowUpdateTime:  time.Minute * 5,
 			},
 		},
-		//&job.SnapshotVoteJob{
+		// &job.SnapshotVoteJob{
 		//	SnapshotJobBase: job.SnapshotJobBase{
 		//		Name:           "snapshot_vote_job",
 		//		DatabaseClient: s.databaseClient,
@@ -306,7 +306,7 @@ func (s *service) Jobs() []worker.Job {
 		//		HighUpdateTime: time.Second * 15,
 		//		LowUpdateTime:  time.Minute * 5,
 		//	},
-		//},
+		// },
 	}
 }
 

--- a/service/indexer/internal/worker/token/worker.go
+++ b/service/indexer/internal/worker/token/worker.go
@@ -160,6 +160,7 @@ func (s *service) handleCrossbellAndXDAI(ctx context.Context, message *protocol.
 						Symbol:        "CSB",
 						Decimals:      18,
 					}
+					transfer.Tag = filter.TagTransaction
 				case message.Network == protocol.NetworkCrossbell && sourceData.ContractAddress != "":
 					nftMetadata, err := nft.GetMetadata(
 						message.Network,


### PR DESCRIPTION
Changes：
1. blockscout datasource `Metadata` 需要默认值
2. crossbell worker 会把 `Transaction.Transfers` 整个替换掉。比如 token worker 先处理了 index=-1 的 Transfer，在 crossbell worker 里会把它去掉。所以选择把 crossbell worker 放在前面
3. snapshot worker 里的 metadata 和 sourcedata 写错了
4. token worker 有个逻辑遗漏了 tag

---

待定的问题：
- crossbell worker 运行时间似乎比较长（`/notes/0xc8b960d09c0078c18dcbe7eb9ab9d816bcca8944`）
- snapshot worker 在 append transaction 的时候，每种 message.Network 都会 append 数据
    - 但在取数据时（getSnapshotVotes）似乎并没有 network 这个字段，是不是有很多重复写入
    - 写入的 transaction.Network 使用的是 message.Network 这样是合理的吗