### PR TITLE
Fix concurrency job

### DIFF
--- a/common/shedlock/shedlock.go
+++ b/common/shedlock/shedlock.go
@@ -31,9 +31,9 @@ func (e *Employer) AddJob(name, spec string, timeout time.Duration, cmd cron.Job
 	_, err := e.crontab.AddFunc(spec, func() {
 		if e.DoLock(name, timeout) {
 			defer func() {
-				_ = e.UnLock(name)
-
 				cmd.Run()
+
+				_ = e.UnLock(name)
 			}()
 		}
 	})


### PR DESCRIPTION
1. 原本流程 1-lock -> 2-unlock -> 3-run
2. 3-run 不会在一开始取锁，而是直接执行 job.run
3. 下面两情况会并发执行
    - 进程 A lock -> unlock，然后 run；此时 run 未结束；进程 B 触发定时任务，lock 成功 -> unlock -> run
    - 进程 A lock -> unlock，然后 run；此时 run 未结束；进程 A 按照 spec 定义的时间，再次触发 lock->unlock->run

---

例如定义了 spec 为 每分钟执行一次；但上面的原因导致并发执行，且每次执行时间超过一分钟，就会使进程的 goroutine 越来越多

---

应当在 run 结束后再释放锁