### PR TITLE
fix: exchange_test run forever

### DIFF
--- a/common/exchange/client_test.go
+++ b/common/exchange/client_test.go
@@ -17,13 +17,22 @@ func init() {
 
 // this test might take a while to run (>1 minutes)
 func TestGetSwapPools(t *testing.T) {
+	errs := make(chan error, 100)
+
 	lop.ForEach(exchange.SwapProviders, func(provider exchange.SwapProvider, k int) {
 		lop.ForEach(provider.SwapPools, func(pool exchange.SwapPool, i int) {
 			result, err := client.GetSwapPairs(context.Background(), provider.Name, pool)
 			if err != nil {
-				t.Fatal(err)
+				t.Log(err)
+				errs <- err
 			}
 			t.Log(len(result))
 		})
 	})
+
+	if len(errs) != 0 {
+		for err := range errs {
+			t.Fatal(err)
+		}
+	}
 }


### PR DESCRIPTION
`t.Fatal` 会调用 `runtime.Goexit()` 让当前的 goroutine 退出；如果在里面退出，会导致 lop 没办法等到所有的 goroutine 结束，会一直卡下去