### PR TITLE
fix: debug stuck

### DIFF
--- a/service/indexer/internal/server/server.go
+++ b/service/indexer/internal/server/server.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -320,6 +321,7 @@ func (s *Server) handle(ctx context.Context, message *protocol.Message) (err err
 	loggerx.Global().Info("start indexing data", zap.String("address", message.Address), zap.String("network", message.Network))
 
 	// Ignore triggers
+	loggerx.Global().Info("IndexerDebugBefore IgnoreTrigger: " + message.Network + " " + message.Address)
 	if !message.IgnoreTrigger {
 		if err := s.executeTriggers(ctx, message); err != nil {
 			zap.L().Error("failed to execute trigger", zap.Error(err), zap.String("address", message.Address), zap.String("network", message.Network))
@@ -332,9 +334,11 @@ func (s *Server) handle(ctx context.Context, message *protocol.Message) (err err
 	}
 
 	// Open a database transaction
+	loggerx.Global().Info("IndexerDebugBefore tx Begin: " + message.Network + " " + message.Address)
 	tx := database.Global().WithContext(ctx).Begin()
 
 	// Delete data from this address and reindex it
+	loggerx.Global().Info("IndexerDebugBefore Reindex: " + strconv.FormatBool(message.Reindex) + message.Network + " " + message.Address)
 	if message.Reindex {
 		var hashes []string
 
@@ -383,6 +387,7 @@ func (s *Server) handle(ctx context.Context, message *protocol.Message) (err err
 	var wg sync.WaitGroup
 	var mu sync.Mutex
 
+	loggerx.Global().Info("IndexerDebugBefore datasource: " + message.Network + " " + message.Address)
 	for _, ds := range s.datasources {
 		wg.Add(1)
 		go func(message *protocol.Message, datasource datasource.Datasource) {
@@ -404,10 +409,12 @@ func (s *Server) handle(ctx context.Context, message *protocol.Message) (err err
 		}(message, ds)
 
 	}
+	loggerx.Global().Info("IndexerDebugBefore WaitGroup: " + message.Network + " " + message.Address)
 	wg.Wait()
 
 	transactionsMap := getTransactionsMap(transactions)
 
+	loggerx.Global().Info("IndexerDebugBefore workers: " + message.Network + " " + message.Address)
 	return s.handleWorkers(ctx, message, tx, transactions, transactionsMap)
 }
 


### PR DESCRIPTION
https://www.notion.so/rss3/pregod-indexer-85d42f49ceb84a49b20bbe0a5b89fae9

分析日志可以知道当一个 pod 卡住时，可以确定：
1. 每一个任务仍然能正常走到 276 行和 321 行
2. 但无法再走到最后（defer 内的 291 行）

所以在他们之间加上更多的打印，以便在下次卡住时搞清楚更精细的区间