### PR TITLE
fix: indexer hang

### DIFF
--- a/common/database/database.go
+++ b/common/database/database.go
@@ -99,8 +99,8 @@ func Dial(dsn string, autoMigrate bool) (*gorm.DB, error) {
 	}
 	sqlDB, _ := client.DB()
 
-	sqlDB.SetMaxIdleConns(25)
-	sqlDB.SetMaxOpenConns(200)
+	sqlDB.SetMaxIdleConns(50)
+	sqlDB.SetMaxOpenConns(300)
 	sqlDB.SetConnMaxLifetime(time.Hour)
 
 	return client, nil

--- a/deploy/prod/hpa.yaml
+++ b/deploy/prod/hpa.yaml
@@ -18,7 +18,7 @@ metadata:
   name: pregod-1-1-indexer
   namespace: pregod
 spec:
-  maxReplicas: 15
+  maxReplicas: 10
   minReplicas: 3
   scaleTargetRef:
     apiVersion: apps/v1

--- a/service/indexer/internal/server/server.go
+++ b/service/indexer/internal/server/server.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
-	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -292,7 +291,6 @@ func (s *Server) handle(ctx context.Context, message *protocol.Message) (err err
 
 	var transactions []model.Transaction
 	defer func() {
-		loggerx.Global().Info("completion start: " + message.Network + " " + message.Address)
 		cancel()
 		s.employer.UnLock(lockKey)
 
@@ -324,52 +322,24 @@ func (s *Server) handle(ctx context.Context, message *protocol.Message) (err err
 
 	loggerx.Global().Info("start indexing data", zap.String("address", message.Address), zap.String("network", message.Network))
 
-	// Open a database transaction
-	loggerx.Global().Info("IndexerDebugBefore tx Begin: " + message.Network + " " + message.Address)
-	tx := database.Global().WithContext(ctx).Begin()
-
-	// Delete data from this address and reindex it
-	loggerx.Global().Info("IndexerDebugBefore Reindex: " + strconv.FormatBool(message.Reindex) + message.Network + " " + message.Address)
-	if message.Reindex {
-		var hashes []string
-
-		// TODO Use the owner to replace hashes field
-		// Get all hashes of this address on this network
-		if err := tx.
-			Model((*model.Transaction)(nil)).
-			Where("network = ? AND owner = ?", message.Network, message.Address).
-			Pluck("hash", &hashes).
-			Error; err != nil {
-			return err
-		}
-
-		if err := tx.Where("network = ? AND hash IN (SELECT * FROM UNNEST(?::TEXT[]))", message.Network, pq.Array(hashes)).Delete(&model.Transaction{}).Error; err != nil {
-			tx.Rollback()
-			return err
-		}
-
-		if err := tx.Where("network = ? AND transaction_hash IN (SELECT * FROM UNNEST(?::TEXT[]))", message.Network, pq.Array(hashes)).Delete(&model.Transfer{}).Error; err != nil {
-			tx.Rollback()
-			return err
-		}
-	}
-
 	// Get the time of the latest data for this address and network
 	var result struct {
 		Timestamp   time.Time `gorm:"column:timestamp"`
 		BlockNumber int64     `gorm:"column:block_number"`
 	}
 
-	if err := tx.
-		Model((*model.Transaction)(nil)).
-		Select("COALESCE(timestamp, 'epoch'::timestamp) AS timestamp, COALESCE(block_number, 0) AS block_number").
-		Where("owner = ?", message.Address).
-		Where("network = ?", message.Network).
-		Order("timestamp DESC").
-		Limit(1).
-		First(&result).
-		Error; err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
-		return err
+	if !message.Reindex {
+		if err := database.Global().
+			Model((*model.Transaction)(nil)).
+			Select("COALESCE(timestamp, 'epoch'::timestamp) AS timestamp, COALESCE(block_number, 0) AS block_number").
+			Where("owner = ?", message.Address).
+			Where("network = ?", message.Network).
+			Order("timestamp DESC").
+			Limit(1).
+			First(&result).
+			Error; err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+			return err
+		}
 	}
 
 	message.Timestamp = result.Timestamp
@@ -378,7 +348,6 @@ func (s *Server) handle(ctx context.Context, message *protocol.Message) (err err
 	var wg sync.WaitGroup
 	var mu sync.Mutex
 
-	loggerx.Global().Info("IndexerDebugBefore datasource: " + message.Network + " " + message.Address)
 	for _, ds := range s.datasources {
 		wg.Add(1)
 		go func(message *protocol.Message, datasource datasource.Datasource) {
@@ -408,13 +377,11 @@ func (s *Server) handle(ctx context.Context, message *protocol.Message) (err err
 		}(message, ds)
 
 	}
-	loggerx.Global().Info("IndexerDebugBefore WaitGroup: " + message.Network + " " + message.Address)
 	wg.Wait()
 
 	transactionsMap := getTransactionsMap(transactions)
 
-	loggerx.Global().Info("IndexerDebugBefore workers: " + message.Network + " " + message.Address)
-	return s.handleWorkers(ctx, message, tx, transactions, transactionsMap)
+	return s.handleWorkers(ctx, message, transactions, transactionsMap)
 }
 
 func (s *Server) handleAsset(ctx context.Context, message *protocol.Message) (err error) {
@@ -590,7 +557,7 @@ func (s *Server) upsertTransactions(ctx context.Context, message *protocol.Messa
 	return tx.Commit().Error
 }
 
-func (s *Server) handleWorkers(ctx context.Context, message *protocol.Message, tx *gorm.DB, transactions []model.Transaction, transactionsMap map[string]model.Transaction) (err error) {
+func (s *Server) handleWorkers(ctx context.Context, message *protocol.Message, transactions []model.Transaction, transactionsMap map[string]model.Transaction) (err error) {
 	tracer := otel.Tracer("indexer")
 	ctx, span := tracer.Start(ctx, "indexer:handleWorkers")
 
@@ -626,6 +593,34 @@ func (s *Server) handleWorkers(ctx context.Context, message *protocol.Message, t
 
 				transactions = transactionsMap2Array(transactionsMap)
 			}
+		}
+	}
+
+	// Open a database transaction
+	tx := database.Global().WithContext(ctx).Begin()
+
+	// Delete data from this address and reindex it
+	if message.Reindex {
+		var hashes []string
+
+		// TODO Use the owner to replace hashes field
+		// Get all hashes of this address on this network
+		if err := tx.
+			Model((*model.Transaction)(nil)).
+			Where("network = ? AND owner = ?", message.Network, message.Address).
+			Pluck("hash", &hashes).
+			Error; err != nil {
+			return err
+		}
+
+		if err := tx.Where("network = ? AND hash IN (SELECT * FROM UNNEST(?::TEXT[]))", message.Network, pq.Array(hashes)).Delete(&model.Transaction{}).Error; err != nil {
+			tx.Rollback()
+			return err
+		}
+
+		if err := tx.Where("network = ? AND transaction_hash IN (SELECT * FROM UNNEST(?::TEXT[]))", message.Network, pq.Array(hashes)).Delete(&model.Transfer{}).Error; err != nil {
+			tx.Rollback()
+			return err
 		}
 	}
 


### PR DESCRIPTION
> 卡住分析 https://www.notion.so/rss3/pregod-indexer-85d42f49ceb84a49b20bbe0a5b89fae9#53a52361b4f44db9884d8eceef268cc2

结论：
1. 配置的 MaxOpenConns 达到上限的时候，`WithContext().Begin()` 会卡住，直到有一个 tx Commit

解决方法：
1. 适当增大 MaxOpenConns
2. 缩短 tx.Begin 到 Commit 的时间
    - datasource 取数据（WaitGroup 声明到结束）的部分没有用到 tx，把它挪到 tx 开始之前
    - datasource 取数据要用到 db 取出来的最近的数据，但这个可以不被包含在 tx 内
    - 更改之后的逻辑：
        * 如果不是 reindex，单句sql执行取到最近的 ts / blocknumber
        * datasource 取数据
        * 开始 tx
        * 如果 reindex 删除数据
        * handleworkers

---

这个 PR 的本地测试，包括从头开始和两分钟后 reindex，完全一致：
|Local|Prod|
|--|--|
|![image](https://user-images.githubusercontent.com/10897528/194788555-9db91d36-d17e-4534-8925-388da912a651.png)|![image](https://user-images.githubusercontent.com/10897528/194788561-7f238119-4dcf-44ea-ba2d-2c3861a3676f.png)|