### PR TITLE
fix: mq 429

### DIFF
--- a/service/hub/internal/server/service/service.go
+++ b/service/hub/internal/server/service/service.go
@@ -102,24 +102,22 @@ func (s *Service) PublishIndexerMessage(ctx context.Context, message protocol.Me
 		protocol.NetworkEIP1577,
 	}
 
-	go func() {
-		for _, network := range networks {
-			message.Network = network
+	for _, network := range networks {
+		message.Network = network
 
-			messageData, err := json.Marshal(&message)
-			if err != nil {
-				return
-			}
-
-			if err := s.rabbitmqChannel.Publish(protocol.ExchangeJob, protocol.IndexerWorkRoutingKey, false, false, rabbitmq.Publishing{
-				ContentType: protocol.ContentTypeJSON,
-				Body:        messageData,
-			}); err != nil {
-				loggerx.Global().Error("publish indexer message failed", zap.Error(err))
-				return
-			}
+		messageData, err := json.Marshal(&message)
+		if err != nil {
+			return
 		}
-	}()
+
+		if err := s.rabbitmqChannel.Publish(protocol.ExchangeJob, protocol.IndexerWorkRoutingKey, false, false, rabbitmq.Publishing{
+			ContentType: protocol.ContentTypeJSON,
+			Body:        messageData,
+		}); err != nil {
+			loggerx.Global().Error("publish indexer message failed", zap.Error(err))
+			return
+		}
+	}
 }
 
 // publishIndexerAssetMessage create a rabbitmq job to index the latest user data


### PR DESCRIPTION
debug： https://www.notion.so/rss3/push-rabbitmq-0428c8ea24bf4a7ebdbc3cd60b04b204

1. 阿里云 rabbitmq 当前配置限制每秒请求数 1000，超过限制时那条连接会被断开；平时使用在个位数
2. 假设一个地址顺序发八条消息需要 100ms，那只能同时允许 1000/(1000ms/100ms)/8 = 12.5 个地址在并发发送消息
    - 我觉得发送消息不算特别耗时，做成同步的也没有什么问题。这里还是先改成最大允许并发 10
3. 本地环境和线上差太多，时间没有办法测试的特别准确；测试了改成 chunk(10) 是正常运行的；这个接口花时间最多地方在 `middlewarex.ResolveAddress(v, request.IgnoreContract)`

---

代码改动：
- 最终发送的地方 `PublishIndexerMessage` 改成同步发送消息
- `BatchGetNotes` 里改成 chunk(10) 并发调用 `PublishIndexerMessage`