### PR TITLE
fix: indexer can not consum msg when mq restart

### DIFF
--- a/service/hub/internal/server/service/service.go
+++ b/service/hub/internal/server/service/service.go
@@ -38,8 +38,11 @@ func New() (s *Service) {
 		for {
 			<-s.rabbitmqConnection.NotifyClose(make(chan *rabbitmq.Error))
 			loggerx.Global().Error("rabbitmq connection closed, reconnecting...")
+			time.Sleep(10 * time.Second)
 			if err := s.connectMQ(); err != nil {
 				loggerx.Global().Error("connect mq failed", zap.Error(err))
+			} else {
+				loggerx.Global().Info("connect mq success", zap.Error(err))
 			}
 			maxRetry--
 			if maxRetry == 0 {


### PR DESCRIPTION
- 修复: mq 重启后indexer无法获取最新的connection，导致无法消费消息
- 建议: 增加mq重连间隔，防止快速重连达到最大次数后直接panic 