### PR TITLE
fix(job/token): invalid token id

### DIFF
--- a/service/indexer/internal/worker/transaction/job/token/job.go
+++ b/service/indexer/internal/worker/transaction/job/token/job.go
@@ -214,19 +214,23 @@ func (j *Job) buildTokenListFromZkSync(ctx context.Context, tokenList zksync.Get
 			return strings.EqualFold(contractAddress, token.Address)
 		})
 
-		var logo string
+		var logo, id string
 
 		if exists {
 			j.rateLimiter.Take()
 
-			coin, err := j.coingeckoClient.Coin(ctx, coin.ID, coingecko.CoinParameter{})
+			coingeckoCoin, err := j.coingeckoClient.Coin(ctx, coin.ID, coingecko.CoinParameter{})
 			if err != nil {
 				zap.L().Warn("fetch token from coingecko", zap.String("job", j.Name()), zap.String("token", token.Symbol), zap.String("contract_address", token.Address), zap.Error(err))
 
 				continue
 			}
 
-			logo, _ = j.buildLogoURL(*coin)
+			logo, _ = j.buildLogoURL(*coingeckoCoin)
+
+			id = strings.ToLower(coin.ID)
+		} else {
+			id = strings.ToLower(token.Symbol)
 		}
 
 		ethereumClient, err := ethclientx.Global(protocol.NetworkEthereum)
@@ -241,7 +245,7 @@ func (j *Job) buildTokenListFromZkSync(ctx context.Context, tokenList zksync.Get
 			continue
 		}
 
-		internalToken.ID = coin.ID
+		internalToken.ID = id
 		internalToken.Decimal = token.Decimals
 
 		tokens = append(tokens, *internalToken)


### PR DESCRIPTION
Some of ZkSync's tokens failed to match in CoinGecko, resulting in an empty string for the ID.