### PR TITLE
fix: hub beat error

### DIFF
--- a/service/hub/internal/server/handler/handler.go
+++ b/service/hub/internal/server/handler/handler.go
@@ -52,11 +52,14 @@ func (h *Handler) filterReport(path string, request interface{}) {
 		report["index"] = model.EsIndex
 		report["path"] = path
 		report["ts"] = time.Now().Format("2006-01-02 15:04:05")
-		for _, address := range report["address"].([]interface{}) {
-			report["address"] = address
 
-			output, _ := json.Marshal(report)
-			fmt.Printf("[DATABEAT]%v\n", string(output))
+		if addresses, ok := report["address"].([]interface{}); ok {
+			for _, address := range addresses {
+				report["address"] = address
+
+				output, _ := json.Marshal(report)
+				fmt.Printf("[DATABEAT]%v\n", string(output))
+			}
 		}
 	}
 }


### PR DESCRIPTION
```
{"level":"warn","ts":1669020379.70883,"caller":"middlewarex/zap.go:37","msg":"request is invalid","status":400,"method":"POST","uri":"/notes","user_agent":"HTTPie/2.6.0","client_ip":"85.128.106.18"}
[DATABEAT]{"api_key":"","count":true,"index":"pregod-v1-visit-path","path":"/notes","remote_addr":"85.128.106.18","ts":"2022-11-21 08:46:19"}
panic: interface conversion: interface {} is nil, not []interface {}
goroutine 77816 [running]:
github.com/naturalselectionlabs/pregod/service/hub/internal/server/handler.(*Handler).filterReport(0x10000c001aca000?, {0x10e385a, 0x6}, {0x109a240?, 0xc0001a49c0?})
 /rss3-pregod/service/hub/internal/server/handler/handler.go:55 +0x5c5
created by github.com/naturalselectionlabs/pregod/service/hub/internal/server/handler.(*Handler).BatchGetNotesFunc
 /rss3-pregod/service/hub/internal/server/handler/handler_note.go:85 +0x2ea
```