### PR TITLE
feat: eth node use websocket

### DIFF
--- a/common/ethclientx/ethclientx.go
+++ b/common/ethclientx/ethclientx.go
@@ -58,8 +58,8 @@ func Dial(config *configx.RPC, networks []string) (ethereumClientMap map[string]
 	ethereumClientMap = make(map[string]*ethclient.Client)
 
 	if config.General.Ethereum != nil && slices.Contains(networks, protocol.NetworkEthereum) {
-		globalEthereumUrlMap[protocol.NetworkEthereum] = config.General.Ethereum.HTTP
-		if ethereumClientMap[protocol.NetworkEthereum], err = ethclient.Dial(config.General.Ethereum.HTTP); err != nil {
+		globalEthereumUrlMap[protocol.NetworkEthereum] = config.General.Ethereum.WebSocket
+		if ethereumClientMap[protocol.NetworkEthereum], err = ethclient.Dial(config.General.Ethereum.WebSocket); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/token/client_test.go
+++ b/internal/token/client_test.go
@@ -19,7 +19,7 @@ func init() {
 	rpcConfig := configx.RPC{
 		General: configx.RPCNetwork{
 			Ethereum: &configx.RPCEndpoint{
-				HTTP: "https://rpc.rss3.dev/networks/ethereum",
+				WebSocket: "https://rpc.rss3.dev/networks/ethereum",
 			},
 		},
 	}

--- a/service/hub/internal/server/middlewarex/apiHandleMiddleware_test.go
+++ b/service/hub/internal/server/middlewarex/apiHandleMiddleware_test.go
@@ -15,7 +15,7 @@ func init() {
 	rpcConfig := configx.RPC{
 		General: configx.RPCNetwork{
 			Ethereum: &configx.RPCEndpoint{
-				HTTP: "https://rpc.ankr.com/eth",
+				WebSocket: "https://rpc.ankr.com/eth",
 			},
 			Polygon: &configx.RPCEndpoint{
 				HTTP: "https://rpc.ankr.com/polygon",

--- a/service/indexer/internal/worker/transaction/worker_test.go
+++ b/service/indexer/internal/worker/transaction/worker_test.go
@@ -42,7 +42,7 @@ func init() {
 	rpcConfig := &configx.RPC{
 		General: configx.RPCNetwork{
 			Ethereum: &configx.RPCEndpoint{
-				HTTP: "https://rpc.rss3.dev/networks/ethereum",
+				WebSocket: "https://rpc.rss3.dev/networks/ethereum",
 			},
 		},
 	}


### PR DESCRIPTION
访问量大，频繁 429，需要换用自建节点。

---

但是改用自建节点以后连接数过大，一段时间后 `NON_ESTABLISHED` 指标几乎等于总 TCP 连接数。

![image](https://user-images.githubusercontent.com/10897528/208390130-bb878aa2-12e8-4c6a-87ec-05c1b0ea5ca7.png)

而且此时内存也会因为连接数过多而迅速上涨。

1. go-ethereum 看起来已经在用 go 标准库的 http（默认有连接复用）；没有搜索到 go-ethereum 复用连接的相关问题。猜测应该是对 eth 节点瞬时请求过高所以瞬时连接很高。
2. 本地试用了一下 websocket 是可用的。

---

配置改动：

```yaml
rpc:
  general:
    ethereum:
      websocket: wss://rss3:MYW4pMELrou5jEHG@proxy.rss3.dev/ws/eth
```