### PR TITLE
fix: the space id does not have a resolver

### DIFF
--- a/common/worker/name_service/spaceid/spaceid.go
+++ b/common/worker/name_service/spaceid/spaceid.go
@@ -41,7 +41,7 @@ func (c *Client) GetProfile(address string) (*social.Profile, error) {
 	if resolver == ethereum.AddressGenesis {
 		loggerx.Global().Error("the space id does not have a resolver: ", zap.Error(err))
 
-		return nil, err
+		return nil, fmt.Errorf("the space id does not have a resolver")
 	}
 
 	spaceidResolver, err := spaceidcontract.NewResolver(resolver, c.ethClient)


### PR DESCRIPTION
访问：https://test-pregod.rss3.dev/v1/ns/0xe02a52a553acf14cd5552e53d48dc0fc072978d8

会得到这个错误导致 hub 退出
![image](https://user-images.githubusercontent.com/10897528/208398865-d04fc39b-e214-4f25-895c-f5245dacdced.png)


报错出现在 269 行 `return profile.Handle, nil`，上面有检查 err，说明 `spaceidClient.GetProfile` return 了 `nil, nil`

看起来只有这里会返回两个 nil