### PR TITLE
fix: limit hub replicas

### DIFF
--- a/deploy/prod/deploy-hub.yaml
+++ b/deploy/prod/deploy-hub.yaml
@@ -29,11 +29,11 @@ spec:
               protocol: TCP
           resources:
             requests:
-              memory: "50Mi"
-              cpu: "50m"
+              memory: "200Mi"
+              cpu: "500m"
             limits:
-              memory: "1000Mi"
-              cpu: "300m"
+              memory: "2000Mi"
+              cpu: "1500m"
           readinessProbe:
             httpGet:
               path: /

--- a/deploy/prod/hpa.yaml
+++ b/deploy/prod/hpa.yaml
@@ -18,7 +18,7 @@ metadata:
   name: pregod-1-1-indexer
   namespace: pregod
 spec:
-  maxReplicas: 20
+  maxReplicas: 5
   minReplicas: 3
   scaleTargetRef:
     apiVersion: apps/v1


### PR DESCRIPTION
看起来似乎因为每一份 hub 都会创建匿名的 queue 然后收到广播消息，所以 hub 数量越多消息数量会成倍提升。所以有必要限制 hub 的数量