### PR TITLE
feat: DATABEAT visit-path add real ip

### DIFF
--- a/service/hub/internal/server/handler/handler.go
+++ b/service/hub/internal/server/handler/handler.go
@@ -33,7 +33,7 @@ func (h *Handler) apiReport(path string, c echo.Context) {
 	fmt.Printf("[DATABEAT]%v\n", string(output))
 }
 
-func (h *Handler) filterReport(path string, request interface{}) {
+func (h *Handler) filterReport(path string, request interface{}, c echo.Context) {
 	b, _ := json.Marshal(request)
 	report := make(map[string]interface{})
 
@@ -52,6 +52,7 @@ func (h *Handler) filterReport(path string, request interface{}) {
 		report["index"] = model.EsIndex
 		report["path"] = path
 		report["ts"] = time.Now().Format("2006-01-02 15:04:05")
+		report["remote_addr"] = c.RealIP()
 
 		if addresses, ok := report["address"].([]interface{}); ok {
 			for _, address := range addresses {

--- a/service/hub/internal/server/handler/handler_name_service.go
+++ b/service/hub/internal/server/handler/handler_name_service.go
@@ -31,7 +31,7 @@ func (h *Handler) GetNameResolveFunc(c echo.Context) error {
 		return AddressIsEmpty(c)
 	}
 
-	go h.filterReport(model.GetNS, request)
+	go h.filterReport(model.GetNS, request, c)
 
 	result := name_service.ReverseResolveAll(strings.ToLower(request.Address), true)
 

--- a/service/hub/internal/server/handler/handler_note.go
+++ b/service/hub/internal/server/handler/handler_note.go
@@ -35,7 +35,7 @@ func (h *Handler) GetNotesFunc(c echo.Context) error {
 
 	// api report
 	if len(request.Cursor) == 0 {
-		go h.filterReport(model.GetNotes, request)
+		go h.filterReport(model.GetNotes, request, c)
 	}
 
 	transactions, total, err := h.service.GetNotes(ctx, request)
@@ -82,7 +82,7 @@ func (h *Handler) BatchGetNotesFunc(c echo.Context) error {
 	}
 
 	if len(request.Cursor) == 0 {
-		go h.filterReport(model.PostNotes, request)
+		go h.filterReport(model.PostNotes, request, c)
 	}
 
 	if len(request.Address) == 0 {

--- a/service/hub/internal/server/handler/handler_profile.go
+++ b/service/hub/internal/server/handler/handler_profile.go
@@ -29,7 +29,7 @@ func (h *Handler) GetProfilesFunc(c echo.Context) error {
 		return err
 	}
 
-	go h.filterReport(model.GetProfiles, request)
+	go h.filterReport(model.GetProfiles, request, c)
 
 	profileList, err := h.service.GetProfiles(ctx, request)
 	if err != nil {
@@ -60,7 +60,7 @@ func (h *Handler) BatchGetProfilesFunc(c echo.Context) error {
 		return err
 	}
 
-	go h.filterReport(model.PostProfiles, request)
+	go h.filterReport(model.PostProfiles, request, c)
 
 	if len(request.Address) > model.DefaultLimit {
 		request.Address = request.Address[:model.DefaultLimit]


### PR DESCRIPTION
已经没有办法了，需要通过打点来分析是谁在请求然后 block；已经做了这些事情：
1. 修复 indexer 报错
2. rabbitmq 升配拉到当前配置允许的最大消息量
3. 换成 quicknode 节点而不是自建
4. indexer 跑到 30 个
5. block 掉一些请求比较明显的 IP

- 还是会刷不出来（indexer 压根得不到需要刷新的地址，与此同时 hub 并没有报出 发送失败的错误）
- mq 升配前每五分钟都会有每秒消息量都达到数千，升配后变得更多到上万，而且不再五分钟一次而是随时
- 自建 eth 节点 CPU 已经是高频 40 核心，会打到 95%