### PR TITLE
feat: separate indexer for io

### DIFF
--- a/common/config/config.go
+++ b/common/config/config.go
@@ -58,11 +58,12 @@ func (k *Kurora) String() string {
 var _ fmt.Stringer = &RabbitMQ{}
 
 type RabbitMQ struct {
-	TLS      bool   `mapstructure:"tls"`
-	Host     string `mapstructure:"host"`
-	Port     int    `mapstructure:"port"`
-	User     string `mapstructure:"user"`
-	Password string `mapstructure:"password"`
+	TLS       bool   `mapstructure:"tls"`
+	Host      string `mapstructure:"host"`
+	Port      int    `mapstructure:"port"`
+	User      string `mapstructure:"user"`
+	Password  string `mapstructure:"password"`
+	QueueWork string `mapstructure:"queue_work"`
 }
 
 func (r *RabbitMQ) String() string {

--- a/common/constant/constant.go
+++ b/common/constant/constant.go
@@ -1,0 +1,12 @@
+package constant
+
+// should not use built-in type string as key for value; define your own type to avoid collisions
+type APIKeyCtxKey string
+
+const (
+	// https://www.notion.so/rss3/io-APIkey-eccfd84c6afc420c9294e14aff9ddf34
+	API_KEY_HEADER = "X-API-KEY"
+	IO_API_Key     = "25092829-33b4-4ed2-a466-ee4873dc58d5"
+
+	API_KEY_CTX_KEY = APIKeyCtxKey(API_KEY_HEADER)
+)

--- a/common/protocol/constant.go
+++ b/common/protocol/constant.go
@@ -1,16 +1,24 @@
 package protocol
 
 const (
-	Version                = "v1.1.0"
-	Build                  = ""
-	ExchangeJob            = "pregod11.jobs"
-	IndexerWorkQueue       = "pregod11.indexer.work"
-	IndexerWorkRoutingKey  = "pregod11.indexer.work"
-	IndexerAssetQueue      = "pregod11.indexer.asset"
-	IndexerAssetRoutingKey = "pregod11.indexer.asset"
-	ContentTypeJSON        = "application/json"
+	Version               = "v1.1.0"
+	Build                 = ""
+	ExchangeJob           = "pregod11.jobs"
+	IndexerWorkQueue      = "pregod11.indexer.work"
+	IndexerWorkRoutingKey = "pregod11.indexer.work"
+	// https://www.notion.so/rss3/io-APIkey-eccfd84c6afc420c9294e14aff9ddf34
+	IndexerWorkQueueIO      = "pregod11.indexer-io.work"
+	IndexerWorkRoutingKeyIO = "pregod11.indexer-io.work"
+	IndexerAssetQueue       = "pregod11.indexer.asset"
+	IndexerAssetRoutingKey  = "pregod11.indexer.asset"
+	ContentTypeJSON         = "application/json"
 
 	ExchangeRefresh = "pregod11.refresh"
 
 	IndexVirtual int64 = -1
 )
+
+var WorkQ2RoutingKey = map[string]string{
+	IndexerWorkQueue:   IndexerWorkRoutingKey,
+	IndexerWorkQueueIO: IndexerWorkRoutingKeyIO,
+}

--- a/deploy/config/indexer.yaml
+++ b/deploy/config/indexer.yaml
@@ -23,6 +23,7 @@ rabbitmq:
   port: 5672
   user: guest
   password: guest
+  queue_work: "pregod11.indexer.work"
 
 opentelemetry:
   enabled: false

--- a/deploy/dev/deploy-indexer-io.yaml
+++ b/deploy/dev/deploy-indexer-io.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pregod-1-1-indexer-io
+  namespace: pregod
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: pregod-1-1-indexer-io
+  template:
+    metadata:
+      labels:
+        app: pregod-1-1-indexer-io
+    spec:
+      containers:
+        - image: $IMAGE_TAG_RELEASE
+          imagePullPolicy: Always
+          name: pregod-1-1
+          envFrom:
+            - secretRef:
+                name: pregod-1-1
+          env:
+            - name: CONFIG_ENV_RABBITMQ_QUEUE_WORK
+              value: "pregod11.indexer-io.work"
+          command:
+            - indexer
+          resources:
+            requests:
+              memory: "400Mi"
+              cpu: "300m"
+            limits:
+              memory: "6000Mi"
+              cpu: "3000m"

--- a/deploy/prod/deploy-indexer-io.yaml
+++ b/deploy/prod/deploy-indexer-io.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pregod-1-1-indexer-io
+  namespace: pregod
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: pregod-1-1-indexer-io
+  template:
+    metadata:
+      labels:
+        app: pregod-1-1-indexer-io
+    spec:
+      containers:
+        - image: $IMAGE_TAG_RELEASE
+          imagePullPolicy: Always
+          name: pregod-1-1-io
+          envFrom:
+            - secretRef:
+                name: pregod-1-1
+          env:
+            - name: CONFIG_ENV_RABBITMQ_QUEUE_WORK
+              value: "pregod11.indexer-io.work"
+          command:
+            - indexer
+          resources:
+            requests:
+              memory: "2000Mi"
+              cpu: "1"
+            limits:
+              memory: "12000Mi"
+              cpu: "3"
+      tolerations:
+      - key: "rss3.io/usage"
+        operator: "Exists"
+        effect: "NoSchedule"
+      nodeSelector:
+        rss3.io/usage: indexer

--- a/deploy/prod/hpa.yaml
+++ b/deploy/prod/hpa.yaml
@@ -18,10 +18,24 @@ metadata:
   name: pregod-1-1-indexer
   namespace: pregod
 spec:
-  maxReplicas: 30
+  maxReplicas: 28
   minReplicas: 3
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
     name: pregod-1-1-indexer
+  targetCPUUtilizationPercentage: 80
+---
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: pregod-1-1-indexer-io
+  namespace: pregod
+spec:
+  maxReplicas: 5
+  minReplicas: 2
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: pregod-1-1-indexer-io
   targetCPUUtilizationPercentage: 80

--- a/service/hub/internal/server/handler/handler_note.go
+++ b/service/hub/internal/server/handler/handler_note.go
@@ -1,11 +1,13 @@
 package handler
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
 	"github.com/labstack/echo/v4"
+	"github.com/naturalselectionlabs/pregod/common/constant"
 	dbModel "github.com/naturalselectionlabs/pregod/common/database/model"
 	"github.com/naturalselectionlabs/pregod/service/hub/internal/server/dao"
 	"github.com/naturalselectionlabs/pregod/service/hub/internal/server/middlewarex"
@@ -37,6 +39,10 @@ func (h *Handler) GetNotesFunc(c echo.Context) error {
 	if len(request.Cursor) == 0 {
 		go h.filterReport(model.GetNotes, request, c)
 	}
+
+	// api key
+	apiKey := c.Request().Header.Get(constant.API_KEY_HEADER)
+	ctx = context.WithValue(ctx, constant.API_KEY_CTX_KEY, apiKey)
 
 	transactions, total, err := h.service.GetNotes(ctx, request)
 	if err != nil {
@@ -100,6 +106,10 @@ func (h *Handler) BatchGetNotesFunc(c echo.Context) error {
 		}
 		request.Address[i] = address
 	}
+
+	// api key
+	apiKey := c.Request().Header.Get(constant.API_KEY_HEADER)
+	ctx = context.WithValue(ctx, constant.API_KEY_CTX_KEY, apiKey)
 
 	transactions, total, err := h.service.BatchGetNotes(ctx, request)
 	if err != nil {

--- a/service/hub/internal/server/middlewarex/apiHandleMiddleware.go
+++ b/service/hub/internal/server/middlewarex/apiHandleMiddleware.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/labstack/echo/v4"
+	"github.com/naturalselectionlabs/pregod/common/constant"
 	"github.com/naturalselectionlabs/pregod/common/database"
 	"github.com/naturalselectionlabs/pregod/common/database/model"
 	"github.com/naturalselectionlabs/pregod/common/worker/name_service"
@@ -28,7 +29,7 @@ func APIMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
 			}
 		}
 
-		apiKey := c.Request().Header.Get("X-API-KEY")
+		apiKey := c.Request().Header.Get(constant.API_KEY_HEADER)
 		c.Set("API-KEY", apiKey)
 
 		_ = CheckAPIKey(apiKey)
@@ -44,7 +45,7 @@ func APIMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
 
 func CheckAPIKeyMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
-		apiKey := c.Request().Header.Get("X-API-KEY")
+		apiKey := c.Request().Header.Get(constant.API_KEY_HEADER)
 		c.Set("API-KEY", apiKey)
 
 		_ = CheckAPIKey(apiKey)

--- a/service/indexer/internal/rabbitmq/rabbitmq.go
+++ b/service/indexer/internal/rabbitmq/rabbitmq.go
@@ -1,6 +1,7 @@
 package rabbitmq
 
 import (
+	"fmt"
 	"sync"
 	"time"
 
@@ -111,14 +112,18 @@ func connect(mq *configx.RabbitMQ) (err error) {
 		return err
 	}
 
+	// work queue
+	if protocol.WorkQ2RoutingKey[mq.QueueWork] == "" {
+		return fmt.Errorf("invalid work queue: %s", mq.QueueWork)
+	}
 	if rabbitmqQueue, err = rabbitmqChannel.QueueDeclare(
-		protocol.IndexerWorkQueue, false, false, false, false, nil,
+		mq.QueueWork, false, false, false, false, nil,
 	); err != nil {
 		return err
 	}
 
 	if err := rabbitmqChannel.QueueBind(
-		rabbitmqQueue.Name, protocol.IndexerWorkRoutingKey, protocol.ExchangeJob, false, nil,
+		rabbitmqQueue.Name, protocol.WorkQ2RoutingKey[mq.QueueWork], protocol.ExchangeJob, false, nil,
 	); err != nil {
 		return err
 	}
@@ -128,7 +133,7 @@ func connect(mq *configx.RabbitMQ) (err error) {
 		return err
 	}
 
-	// asset mq
+	// asset queue
 	if rabbitmqAssetQueue, err = rabbitmqChannel.QueueDeclare(
 		protocol.IndexerAssetQueue, false, false, false, false, nil,
 	); err != nil {


### PR DESCRIPTION
io 专用的 indexer。

https://www.notion.so/rss3/io-APIkey-eccfd84c6afc420c9294e14aff9ddf34

## 开发需要的改动

正常启动一个 indexer 配置文件需要增加 `rabbitmq.queue_work: "pregod11.indexer.work"`

## 如何测试

- 本地带 header 和正确的值访问，任务会被分到 indexer-io 进程（修改 queue_work 配置以后再启动的进程）去执行
- 目前 https://dev.hoot.it 可以测试

---

#### 为什么不用 echoctx.Get("X-API-KEY")

虽然在 middleware 里 Set 过，但是再去取是空值，还没搞清楚为什么。所以用了 `Header.Get("X-API-KEY")`