### PR TITLE
feat: indexer-io by origin

### DIFF
--- a/common/constant/constant.go
+++ b/common/constant/constant.go
@@ -1,12 +1,12 @@
 package constant
 
 // should not use built-in type string as key for value; define your own type to avoid collisions
-type APIKeyCtxKey string
+type HeaderCtxKey string
 
 const (
 	// https://www.notion.so/rss3/io-APIkey-eccfd84c6afc420c9294e14aff9ddf34
 	API_KEY_HEADER = "X-API-KEY"
 	IO_API_Key     = "25092829-33b4-4ed2-a466-ee4873dc58d5"
 
-	API_KEY_CTX_KEY = APIKeyCtxKey(API_KEY_HEADER)
+	HEADER_CTX_KEY = HeaderCtxKey("header")
 )

--- a/service/hub/internal/server/handler/handler_note.go
+++ b/service/hub/internal/server/handler/handler_note.go
@@ -40,9 +40,8 @@ func (h *Handler) GetNotesFunc(c echo.Context) error {
 		go h.filterReport(model.GetNotes, request, c)
 	}
 
-	// api key
-	apiKey := c.Request().Header.Get(constant.API_KEY_HEADER)
-	ctx = context.WithValue(ctx, constant.API_KEY_CTX_KEY, apiKey)
+	// header into ctx
+	ctx = context.WithValue(ctx, constant.HEADER_CTX_KEY, c.Request().Header)
 
 	transactions, total, err := h.service.GetNotes(ctx, request)
 	if err != nil {
@@ -107,9 +106,8 @@ func (h *Handler) BatchGetNotesFunc(c echo.Context) error {
 		request.Address[i] = address
 	}
 
-	// api key
-	apiKey := c.Request().Header.Get(constant.API_KEY_HEADER)
-	ctx = context.WithValue(ctx, constant.API_KEY_CTX_KEY, apiKey)
+	// header into ctx
+	ctx = context.WithValue(ctx, constant.HEADER_CTX_KEY, c.Request().Header)
 
 	transactions, total, err := h.service.BatchGetNotes(ctx, request)
 	if err != nil {


### PR DESCRIPTION
根据 origin 里的域名来判断，如果是我们的网站，就走 indexer-io。

## 原因

前端暂时不会动 rss3.io，所以只能后端通过 origin 来进行这个验证；把我们的任务和别人的任务交给不同的 indexer 去处理

![image](https://user-images.githubusercontent.com/10897528/212687028-27b9daf6-559b-45d5-bd04-79f4d7a0cdb3.png)

---

- 虽然很容易伪造，但是目前 1. API 本来就可以直接访问 2. 留给我们项目专用的 indexer-io 数量并没有其余的 indexer 多，所以暂时应该没有什么风险。等以后全上 APIKEY 了再删除掉根据 origin 判断的部分。