### PR TITLE
fix(worker/marketplace): opensea zero dollar purchase

### DIFF
--- a/service/indexer/internal/worker/collectible/marketplace/worker_blur.go
+++ b/service/indexer/internal/worker/collectible/marketplace/worker_blur.go
@@ -76,7 +76,7 @@ func (i *internal) handleBlurOrdersMatched(ctx context.Context, transaction mode
 		return nil, fmt.Errorf("build cost: %w", err)
 	}
 
-	internalTransfer, err := i.buildTradeTransfer(transaction, int64(log.Index), platform, event.Maker, common.HexToAddress(transaction.AddressFrom) /* The buyer address is not output in event. */, *nft, *nft.Cost)
+	internalTransfer, err := i.buildTradeTransfer(transaction, int64(log.Index), platform, event.Maker, common.HexToAddress(transaction.AddressFrom) /* The buyer address is not output in event. */, *nft, nft.Cost)
 	if err != nil {
 		return nil, fmt.Errorf("build trade transfer: %w", err)
 	}

--- a/service/indexer/internal/worker/collectible/marketplace/worker_element.go
+++ b/service/indexer/internal/worker/collectible/marketplace/worker_element.go
@@ -61,7 +61,7 @@ func (i *internal) handleElementERC721SellOrderFilled(ctx context.Context, trans
 		return nil, fmt.Errorf("build cost: %w", err)
 	}
 
-	internalTransfer, err := i.buildTradeTransfer(transaction, int64(log.Index), platform, event.Maker, event.Taker, *nft, *nft.Cost)
+	internalTransfer, err := i.buildTradeTransfer(transaction, int64(log.Index), platform, event.Maker, event.Taker, *nft, nft.Cost)
 	if err != nil {
 		return nil, fmt.Errorf("build trade transfer: %w", err)
 	}
@@ -115,7 +115,7 @@ func (i *internal) handleElementERC1155SellOrderFilled(ctx context.Context, tran
 		return nil, fmt.Errorf("build cost: %w", err)
 	}
 
-	internalTransfer, err := i.buildTradeTransfer(transaction, int64(log.Index), platform, event.Maker, event.Taker, *nft, *nft.Cost)
+	internalTransfer, err := i.buildTradeTransfer(transaction, int64(log.Index), platform, event.Maker, event.Taker, *nft, nft.Cost)
 	if err != nil {
 		return nil, fmt.Errorf("build trade transfer: %w", err)
 	}

--- a/service/indexer/internal/worker/collectible/marketplace/worker_looksrare.go
+++ b/service/indexer/internal/worker/collectible/marketplace/worker_looksrare.go
@@ -46,7 +46,7 @@ func (i *internal) handleLooksRareTakerAsk(ctx context.Context, transaction mode
 	nftValue := decimal.NewFromBigInt(event.Amount, 0)
 	nftMetadata.Value = &nftValue
 
-	tradeTransfer, err := i.buildTradeTransfer(transaction, int64(log.Index), platform, event.Taker, event.Maker, *nftMetadata, *cost)
+	tradeTransfer, err := i.buildTradeTransfer(transaction, int64(log.Index), platform, event.Taker, event.Maker, *nftMetadata, cost)
 	if err != nil {
 		return nil, err
 	}
@@ -92,7 +92,7 @@ func (i *internal) handleLooksRareTakerBid(ctx context.Context, transaction mode
 	nftValue := decimal.NewFromBigInt(event.Amount, 0)
 	nftMetadata.Value = &nftValue
 
-	tradeTransfer, err := i.buildTradeTransfer(transaction, int64(log.Index), platform, event.Maker, event.Taker, *nftMetadata, *cost)
+	tradeTransfer, err := i.buildTradeTransfer(transaction, int64(log.Index), platform, event.Maker, event.Taker, *nftMetadata, cost)
 	if err != nil {
 		return nil, err
 	}

--- a/service/indexer/internal/worker/collectible/marketplace/worker_opensea.go
+++ b/service/indexer/internal/worker/collectible/marketplace/worker_opensea.go
@@ -138,7 +138,7 @@ func (i *internal) handleOpenSeaOrderFulfilled(ctx context.Context, transaction 
 		}
 	}
 
-	internalTransfer, err := i.buildTradeTransfer(transaction, index, platform, seller, buyer, *nft, *cost)
+	internalTransfer, err := i.buildTradeTransfer(transaction, index, platform, seller, buyer, *nft, cost)
 	if err != nil {
 		return nil, fmt.Errorf("build trade transfer: %w", err)
 	}
@@ -255,7 +255,7 @@ func (i *internal) handleOpenSeaOrdersMatched(ctx context.Context, transaction m
 		return nil, err
 	}
 
-	tradeTransfer, err := i.buildTradeTransfer(transaction, int64(log.Index), platform, event.Maker, event.Taker, *nft, *cost)
+	tradeTransfer, err := i.buildTradeTransfer(transaction, int64(log.Index), platform, event.Maker, event.Taker, *nft, cost)
 	if err != nil {
 		return nil, err
 	}

--- a/service/indexer/internal/worker/collectible/marketplace/worker_quix.go
+++ b/service/indexer/internal/worker/collectible/marketplace/worker_quix.go
@@ -53,7 +53,7 @@ func (i *internal) handleQuickSellOrderFilled(ctx context.Context, transaction m
 		return nil, fmt.Errorf("build cost: %w", err)
 	}
 
-	internalTransfer, err := i.buildTradeTransfer(transaction, int64(log.Index), platform, event.Seller, event.Buyer, *nft, *nft.Cost)
+	internalTransfer, err := i.buildTradeTransfer(transaction, int64(log.Index), platform, event.Seller, event.Buyer, *nft, nft.Cost)
 	if err != nil {
 		return nil, fmt.Errorf("build trade transfer: %w", err)
 	}

--- a/service/indexer/internal/worker/collectible/marketplace/worker_test.go
+++ b/service/indexer/internal/worker/collectible/marketplace/worker_test.go
@@ -159,6 +159,43 @@ func Test_internal_Handle(t *testing.T) {
 			wantErr: assert.NoError,
 		},
 		{
+			name: "opensea seaport zero dollar purchase",
+			arguments: arguments{
+				ctx: context.Background(),
+				message: &protocol.Message{
+					Address: "0xc5bacbb46b18cd035c1063d16d32c6bdcf541de8", // Unknown
+					Network: protocol.NetworkEthereum,
+				},
+				transactions: []model.Transaction{
+					{
+						// https://etherscan.io/tx/0x7df97b3ef1d5d5b0fe913a40488975c004c27933abbe7acdad04e5f1b6657a7a
+						Hash:        "0x7df97b3ef1d5d5b0fe913a40488975c004c27933abbe7acdad04e5f1b6657a7a",
+						BlockNumber: 15323187,
+						Network:     protocol.NetworkEthereum,
+					},
+				},
+			},
+			want: func(t assert.TestingT, i interface{}, i2 ...interface{}) bool {
+				transactions, ok := i.([]model.Transaction)
+				if !ok {
+					return false
+				}
+
+				assert.NotEmpty(t, transactions)
+
+				for _, transaction := range transactions {
+					_, _ = pp.Println(transaction)
+
+					if !assert.Equal(t, transaction.Platform, protocol.PlatformOpenSea) {
+						return false
+					}
+				}
+
+				return false
+			},
+			wantErr: assert.NoError,
+		},
+		{
 			name: "opensea wyvern exchange v1",
 			arguments: arguments{
 				ctx: context.Background(),

--- a/service/indexer/internal/worker/collectible/marketplace/worker_tofunft.go
+++ b/service/indexer/internal/worker/collectible/marketplace/worker_tofunft.go
@@ -72,7 +72,7 @@ func (i *internal) handleTofuNFTEvInventoryUpdate(ctx context.Context, transacti
 	nftValue := decimal.NewFromInt(1)
 	nftMetadata.Value = &nftValue
 
-	tradeTransfer, err := i.buildTradeTransfer(transaction, int64(log.Index), platform, event.Inventory.Seller, event.Inventory.Buyer, *nftMetadata, *cost)
+	tradeTransfer, err := i.buildTradeTransfer(transaction, int64(log.Index), platform, event.Inventory.Seller, event.Inventory.Buyer, *nftMetadata, cost)
 	if err != nil {
 		return nil, fmt.Errorf("build trade transfer: %w", err)
 	}


### PR DESCRIPTION
```
=== RUN   Test_internal_Handle
--- PASS: Test_internal_Handle (9.61s)
=== RUN   Test_internal_Handle/opensea_seaport_zero_dollar_purchase
model.Transaction{
  BlockNumber: 15323187,
  Timestamp:   2022-08-12 05:57:45 Local,
  Hash:        "0x7df97b3ef1d5d5b0fe913a40488975c004c27933abbe7acdad04e5f1b6657a7a",
  Index:       294,
  Owner:       "",
  Fee:         &decimal.Decimal{
    value: &big.Int{
      neg: false,
      abs: big.nat{
        2204453101015512,
      },
    },
    exp: -18,
  },
  AddressFrom: "0xc5bacbb46b18cd035c1063d16d32c6bdcf541de8",
  AddressTo:   "0x00000000006c3852cbef3e08e8df289169ede581",
  Addresses:   pq.StringArray(nil),
  Network:     "ethereum",
  Platform:    "OpenSea",
  Source:      "",
  Tag:         "collectible",
  Type:        "trade",
  Success:     &true,
  SourceData:  json.RawMessage{...},
  CreatedAt:   1-01-01 00:00:00 UTC,
  UpdatedAt:   1-01-01 00:00:00 UTC,
  Transfers:   []model.Transfer{
    model.Transfer{
      TransactionHash: "0x7df97b3ef1d5d5b0fe913a40488975c004c27933abbe7acdad04e5f1b6657a7a",
      Timestamp:       2022-08-12 05:57:45 Local,
      BlockNumber:     &15323187,
      Tag:             "collectible",
      Type:            "trade",
      Index:           0,
      AddressFrom:     "0x05293eeee552f6cb86da8cf495b1823928a16feb",
      AddressTo:       "0xc5bacbb46b18cd035c1063d16d32c6bdcf541de8",
      Metadata:        json.RawMessage{
        123, 34, 110, 97, 109, 101, 34, 58, 34, 84, 104, 117, 114, 115, 100, 97,
        121, 32, 83, 112, 101, 99, 105, 97, 108, 32, 69, 100, 105, 116, 105, 111,
        110, 32, 35, 51, 34, 44, 34, 115, 121, 109, 98, 111, 108, 34, 58, 34,
        34, 44, 34, 115, 116, 97, 110, 100, 97, 114, 100, 34, 58, 34, 69, 82,
        67, 45, 49, 49, 53, 53, 34, 44, 34, 99, 111, 110, 116, 114, 97, 99,
        116, 95, 97, 100, 100, 114, 101, 115, 115, 34, 58, 34, 48, 120, 52, 66,
        52, 102, 65, 50, 54, 49, 54, 49, 70, 55, 100, 57, 102, 51, 56, 55,
        66, 48, 49, 65, 100, 54, 66, 102, 48, 49, 54, 57, 66, 97, 53, 98,
        48, 70, 51, 65, 56, 53, 34, 44, 34, 105, 109, 97, 103, 101, 34, 58,
        34, 104, 116, 116, 112, 115, 58, 47, 47, 97, 114, 119, 101, 97, 118, 101,
        46, 110, 101, 116, 47, 77, 113, 117, 56, 116, 104, 105, 88, 104, 86, 122,
        71, 113, 119, 74, 106, 80, 118, 54, 52, 77, 101, 108, 68, 72, 110, 54,
        116, 84, 110, 115, 83, 72, 115, 101, 105, 119, 66, 45, 77, 71, 52, 56,
        34, 44, 34, 105, 100, 34, 58, 34, 51, 34, 44, 34, 118, 97, 108, 117,
        101, 34, 58, 34, 49, 34, 44, 34, 118, 97, 108, 117, 101, 95, 100, 105,
        115, 112, 108, 97, 121, 34, 58, 34, 49, 34, 44, 34, 99, 111, 115, 116,
        34, 58, 123, 34, 110, 97, 109, 101, 34, 58, 34, 69, 116, 104, 101, 114,
        101, 117, 109, 34, 44, 34, 115, 121, 109, 98, 111, 108, 34, 58, 34, 69,
        84, 72, 34, 44, 34, 100, 101, 99, 105, 109, 97, 108, 115, 34, 58, 49,
        56, 44, 34, 115, 116, 97, 110, 100, 97, 114, 100, 34, 58, 34, 78, 97,
        116, 105, 118, 101, 34, 44, 34, 105, 109, 97, 103, 101, 34, 58, 34, 104,
        116, 116, 112, 115, 58, 47, 47, 97, 115, 115, 101, 116, 115, 46, 99, 111,
        105, 110, 103, 101, 99, 107, 111, 46, 99, 111, 109, 47, 99, 111, 105, 110,
        115, 47, 105, 109, 97, 103, 101, 115, 47, 50, 55, 57, 47, 108, 97, 114,
        103, 101, 47, 101, 116, 104, 101, 114, 101, 117, 109, 46, 112, 110, 103, 34,
        44, 34, 118, 97, 108, 117, 101, 34, 58, 34, 48, 34, 44, 34, 118, 97,
        108, 117, 101, 95, 100, 105, 115, 112, 108, 97, 121, 34, 58, 34, 48, 34,
        125, 44, 34, 100, 101, 115, 99, 114, 105, 112, 116, 105, 111, 110, 34, 58,
        34, 84, 83, 69, 32, 226, 128, 148, 32, 70, 111, 114, 32, 116, 104, 101,
        32, 99, 117, 108, 116, 117, 114, 101, 34, 44, 34, 97, 116, 116, 114, 105,
        98, 117, 116, 101, 115, 34, 58, 91, 123, 34, 116, 114, 97, 105, 116, 95,
        116, 121, 112, 101, 34, 58, 34, 65, 114, 116, 105, 115, 116, 34, 44, 34,
        118, 97, 108, 117, 101, 34, 58, 34, 112, 114, 111, 102, 106, 117, 110, 34,
        125, 93, 44, 34, 97, 110, 105, 109, 97, 116, 105, 111, 110, 95, 117, 114,
        108, 34, 58, 34, 104, 116, 116, 112, 115, 58, 47, 47, 97, 114, 119, 101,
        97, 118, 101, 46, 110, 101, 116, 47, 50, 49, 95, 78, 56, 115, 107, 83,
        105, 87, 121, 114, 104, 53, 74, 120, 55, 52, 104, 87, 86, 71, 99, 80,
        108, 48, 80, 68, 85, 48, 88, 73, 102, 90, 98, 65, 76, 107, 100, 67,
        67, 68, 69, 34, 125,
      },
      Network:     "ethereum",
      Platform:    "OpenSea",
      Source:      "",
      SourceData:  json.RawMessage(nil),
      RelatedUrls: pq.StringArray{
        "https://etherscan.io/tx/0x7df97b3ef1d5d5b0fe913a40488975c004c27933abbe7acdad04e5f1b6657a7a",
        "https://opensea.io/assets/0x4B4fA26161F7d9f387B01Ad6Bf0169Ba5b0F3A85/3",
        "https://looksrare.org/collections/0x4B4fA26161F7d9f387B01Ad6Bf0169Ba5b0F3A85/3",
      },
      CreatedAt: 1-01-01 00:00:00 UTC,
      UpdatedAt: 1-01-01 00:00:00 UTC,
    },
  },
}
    --- PASS: Test_internal_Handle/opensea_seaport_zero_dollar_purchase (8.35s)
PASS

Process finished with the exit code 0
```