### PR TITLE
Fix/profile not valid handle

### DIFF
--- a/internal/token/client_test.go
+++ b/internal/token/client_test.go
@@ -19,7 +19,7 @@ func init() {
 	rpcConfig := configx.RPC{
 		General: configx.RPCNetwork{
 			Ethereum: &configx.RPCEndpoint{
-				WebSocket: "https://rpc.rss3.dev/networks/ethereum",
+				WebSocket: "https://eth.llamarpc.com",
 			},
 		},
 	}

--- a/service/hub/internal/server/service/profile.go
+++ b/service/hub/internal/server/service/profile.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	kurora "github.com/naturalselectionlabs/kurora/client"
 	"github.com/naturalselectionlabs/pregod/common/database/model/social"
+	"github.com/naturalselectionlabs/pregod/common/datasource/ethereum"
 	"github.com/naturalselectionlabs/pregod/common/protocol"
 	"github.com/naturalselectionlabs/pregod/common/utils/loggerx"
 	"github.com/naturalselectionlabs/pregod/common/worker/crossbell"
@@ -181,7 +182,7 @@ func (s *Service) GetKuroraProfiles(c context.Context, request model.GetRequest)
 			return nil, err
 		}
 
-		if len(profiles) > 0 {
+		if len(profiles) > 0 && profiles[0].Address != ethereum.AddressGenesis {
 			request.Address = profiles[0].Address.String()
 
 			result, err = s.GetKuroraAddress(c, request)
@@ -219,6 +220,10 @@ func (s *Service) GetKuroraProfiles(c context.Context, request model.GetRequest)
 		res := name_service.ReverseResolveAll(request.Address, false)
 		if len(res.Address) == 0 && res.Err != nil {
 			return nil, res.Err
+		}
+
+		if !name_service.IsValidAddress(res.Address) {
+			return nil, fmt.Errorf("%s: %s", name_service.ErrNotEvmAddress, name_service.ReferDoc)
 		}
 
 		request.Address = res.Address

--- a/service/indexer/internal/worker/collectible/marketplace/worker_test.go
+++ b/service/indexer/internal/worker/collectible/marketplace/worker_test.go
@@ -283,14 +283,14 @@ func Test_internal_Handle(t *testing.T) {
 			arguments: arguments{
 				ctx: context.Background(),
 				message: &protocol.Message{
-					Address: "0x8365ae902329bbdc1c8c5dc1618a0ac2546d00b8", // Unknown
+					Address: "0x71d1988c74a2321a4e71b99490a4d61c72fe2c96", // Unknown
 					Network: protocol.NetworkEthereum,
 				},
 				transactions: []model.Transaction{
 					{
-						// https://etherscan.io/tx/0x80280a1766c141befca028166b0473bab8a0a622fa87376ca3525f5d04700451
-						Hash:        "0x80280a1766c141befca028166b0473bab8a0a622fa87376ca3525f5d04700451",
-						BlockNumber: 16095505,
+						// https://etherscan.io/tx/0xceac035ba1023ba84b1c3a457170bf6dd3fe892e9718699eb88c4624efd4625c
+						Hash:        "0xceac035ba1023ba84b1c3a457170bf6dd3fe892e9718699eb88c4624efd4625c",
+						BlockNumber: 16529836,
 						Network:     protocol.NetworkEthereum,
 					},
 				},

--- a/service/indexer/internal/worker/transaction/worker_test.go
+++ b/service/indexer/internal/worker/transaction/worker_test.go
@@ -42,7 +42,7 @@ func init() {
 	rpcConfig := &configx.RPC{
 		General: configx.RPCNetwork{
 			Ethereum: &configx.RPCEndpoint{
-				WebSocket: "https://rpc.rss3.dev/networks/ethereum",
+				WebSocket: "https://eth.llamarpc.com",
 			},
 		},
 	}


### PR DESCRIPTION
- add genesis evm address and not valid handle check
- revert evm address check

1. genesis evm address returns all records
https://pregod.rss3.dev/v1/profiles/0x0000000000000000000000000000000000000000

2. aptos address 
https://pregod.rss3.dev/v1/profiles/0x3834498dbde5c84459f703d39ec37194f25be43047d3ab77515d586c6178b9fd

3. handle, which has not set resovler, returns all records
https://pregod.rss3.dev/v1/profiles/loanswap.crypto

