### PR TITLE
feat: indexer default ws

### DIFF
--- a/common/config/config.go
+++ b/common/config/config.go
@@ -1,6 +1,10 @@
 package configx
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/naturalselectionlabs/pregod/common/protocol"
+)
 
 type Mode string
 
@@ -150,6 +154,36 @@ type RPCNetwork struct {
 	Avalanche         *RPCEndpoint `mapstructure:"avalanche"`
 	Celo              *RPCEndpoint `mapstructure:"celo"`
 	Fantom            *RPCEndpoint `mapstructure:"fantom"`
+}
+
+func (r RPCNetwork) network2EP() map[string]*RPCEndpoint {
+	return map[string]*RPCEndpoint{
+		protocol.NetworkEthereum:          r.Ethereum,
+		protocol.NetworkPolygon:           r.Polygon,
+		protocol.NetworkBinanceSmartChain: r.BinanceSmartChain,
+		protocol.NetworkXDAI:              r.XDAI,
+		protocol.NetworkCrossbell:         r.Crossbell,
+		protocol.NetworkOptimism:          r.Optimism,
+		protocol.NetworkAvalanche:         r.Avalanche,
+		protocol.NetworkCelo:              r.Celo,
+		protocol.NetworkFantom:            r.Fantom,
+	}
+}
+
+func (r RPCNetwork) HTTP(network string) string {
+	mapNetwork := r.network2EP()
+	if mapNetwork[network] == nil {
+		return ""
+	}
+	return mapNetwork[network].HTTP
+}
+
+func (r RPCNetwork) WebSocket(network string) string {
+	mapNetwork := r.network2EP()
+	if mapNetwork[network] == nil {
+		return ""
+	}
+	return mapNetwork[network].WebSocket
 }
 
 type RPCEndpoint struct {

--- a/common/ethclientx/ethclientx.go
+++ b/common/ethclientx/ethclientx.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/ethclient"
 	configx "github.com/naturalselectionlabs/pregod/common/config"
-	"github.com/naturalselectionlabs/pregod/common/protocol"
-	"golang.org/x/exp/slices"
 )
 
 var (
@@ -57,66 +55,13 @@ func ReplaceGlobal(network string, ethereumClient *ethclient.Client) {
 func Dial(config *configx.RPC, networks []string) (ethereumClientMap map[string]*ethclient.Client, err error) {
 	ethereumClientMap = make(map[string]*ethclient.Client)
 
-	if config.General.Ethereum != nil && slices.Contains(networks, protocol.NetworkEthereum) {
-		globalEthereumUrlMap[protocol.NetworkEthereum] = config.General.Ethereum.WebSocket
-		if ethereumClientMap[protocol.NetworkEthereum], err = ethclient.Dial(config.General.Ethereum.WebSocket); err != nil {
-			return nil, err
+	for _, network := range networks {
+		globalEthereumUrlMap[network] = config.General.WebSocket(network)
+		if globalEthereumUrlMap[network] == "" {
+			globalEthereumUrlMap[network] = config.General.HTTP(network)
 		}
-	}
-
-	if config.General.Polygon != nil && slices.Contains(networks, protocol.NetworkPolygon) {
-		globalEthereumUrlMap[protocol.NetworkPolygon] = config.General.Polygon.HTTP
-		if ethereumClientMap[protocol.NetworkPolygon], err = ethclient.Dial(config.General.Polygon.HTTP); err != nil {
-			return nil, err
-		}
-	}
-
-	if config.General.BinanceSmartChain != nil && slices.Contains(networks, protocol.NetworkBinanceSmartChain) {
-		globalEthereumUrlMap[protocol.NetworkBinanceSmartChain] = config.General.BinanceSmartChain.HTTP
-		if ethereumClientMap[protocol.NetworkBinanceSmartChain], err = ethclient.Dial(config.General.BinanceSmartChain.HTTP); err != nil {
-			return nil, err
-		}
-	}
-
-	if config.General.XDAI != nil && slices.Contains(networks, protocol.NetworkXDAI) {
-		globalEthereumUrlMap[protocol.NetworkXDAI] = config.General.XDAI.HTTP
-		if ethereumClientMap[protocol.NetworkXDAI], err = ethclient.Dial(config.General.XDAI.HTTP); err != nil {
-			return nil, err
-		}
-	}
-
-	if config.General.Crossbell != nil && slices.Contains(networks, protocol.NetworkCrossbell) {
-		globalEthereumUrlMap[protocol.NetworkCrossbell] = config.General.Crossbell.HTTP
-		if ethereumClientMap[protocol.NetworkCrossbell], err = ethclient.Dial(config.General.Crossbell.HTTP); err != nil {
-			return nil, err
-		}
-	}
-
-	if config.General.Optimism != nil && slices.Contains(networks, protocol.NetworkOptimism) {
-		globalEthereumUrlMap[protocol.NetworkOptimism] = config.General.Optimism.HTTP
-		if ethereumClientMap[protocol.NetworkOptimism], err = ethclient.Dial(config.General.Optimism.HTTP); err != nil {
-			return nil, err
-		}
-	}
-
-	if config.General.Avalanche != nil && slices.Contains(networks, protocol.NetworkAvalanche) {
-		globalEthereumUrlMap[protocol.NetworkAvalanche] = config.General.Avalanche.HTTP
-		if ethereumClientMap[protocol.NetworkAvalanche], err = ethclient.Dial(config.General.Avalanche.HTTP); err != nil {
-			return nil, err
-		}
-	}
-
-	if config.General.Celo != nil && slices.Contains(networks, protocol.NetworkCelo) {
-		globalEthereumUrlMap[protocol.NetworkCelo] = config.General.Celo.HTTP
-		if ethereumClientMap[protocol.NetworkCelo], err = ethclient.Dial(config.General.Celo.HTTP); err != nil {
-			return nil, err
-		}
-	}
-
-	if config.General.Fantom != nil && slices.Contains(networks, protocol.NetworkFantom) {
-		globalEthereumUrlMap[protocol.NetworkFantom] = config.General.Fantom.HTTP
-		if ethereumClientMap[protocol.NetworkFantom], err = ethclient.Dial(config.General.Fantom.HTTP); err != nil {
-			return nil, err
+		if ethereumClientMap[network], err = ethclient.Dial(globalEthereumUrlMap[network]); err != nil {
+			return nil, fmt.Errorf("failed to dial %s: %w", network, err)
 		}
 	}
 


### PR DESCRIPTION
indexer 默认用 websocket 连接 rpc 节点。

理由：
- indexer 会制造大量请求，如果用 HTTP 连接数非常多，给自建 rpc 节点带来额外的开销。如果 polygon 要改用自建节点，用 ws 会更好。

> 已经在本地测试：修复了 celo 节点的 ws 问题；ava 不提供 ws