### PR TITLE
fix: crawler init ethclient

### DIFF
--- a/service/crawler/internal/server/server.go
+++ b/service/crawler/internal/server/server.go
@@ -90,7 +90,13 @@ func (s *Server) Initialize() (err error) {
 
 	cache.ReplaceGlobal(redisClient)
 
-	ethereumClientMap, err := ethclientx.Dial(s.config.RPC, protocol.EthclientNetworks)
+	ethereumClientMap, err := ethclientx.Dial(s.config.RPC, []string{
+		protocol.NetworkEthereum,
+		protocol.NetworkPolygon,
+		protocol.NetworkBinanceSmartChain,
+		protocol.NetworkXDAI,
+		protocol.NetworkCrossbell,
+	})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
因为 ethclientx.Dial 的改动，crawler 这里应该指明需要初始化哪些网络；否则会指明了网络，但没有配置文件然后报错。

报错 `time="2023-02-06T09:32:05Z" level=fatal msg="failed to dial optimism: dial unix: missing address"`

---

- 现在的逻辑：参数里传了的，就去做初始化。
- 原来的逻辑：如果读到配置文件，就去检查参数里有没有这个配置文件对应的网络，有就初始化。

---

crawler 的配置文件
![image](https://user-images.githubusercontent.com/10897528/216936837-00e266d4-0688-467b-99ff-220fe29812b0.png)
