### PR TITLE
fix: add request header to avoid 403 forbidden 

### DIFF
--- a/internal/token/client.go
+++ b/internal/token/client.go
@@ -2,6 +2,7 @@ package token
 
 import (
 	"errors"
+	"net/http"
 )
 
 var (
@@ -10,8 +11,10 @@ var (
 	ErrorInvalidMetadataFormat = errors.New("invalid metadata format")
 )
 
-type Client struct{}
+type Client struct {
+	httpClient *http.Client
+}
 
 func New() *Client {
-	return &Client{}
+	return &Client{httpClient: &http.Client{}}
 }

--- a/internal/token/client_test.go
+++ b/internal/token/client_test.go
@@ -57,6 +57,7 @@ func TestClient_ERC721(t *testing.T) {
 	assert.NoError(t, err)
 
 	t.Log(erc712)
+	t.Log(string(erc712.Metadata))
 }
 
 func TestClient_ERC1155(t *testing.T) {
@@ -75,4 +76,13 @@ func TestClient_ERC721_ZORA(t *testing.T) {
 	assert.NoError(t, err)
 
 	t.Log(erc712)
+	t.Log(string(erc712.Metadata))
+}
+
+func TestClient_ERC721_403(t *testing.T) {
+	erc712, err := tokenClient.ERC721(context.Background(), protocol.NetworkEthereum, "0xb932a70a57673d89f4acffbe830e8ed7f75fb9e0", big.NewInt(35536))
+	assert.NoError(t, err)
+
+	t.Log(erc712)
+	t.Log(string(erc712.Metadata))
 }

--- a/internal/token/token.go
+++ b/internal/token/token.go
@@ -367,7 +367,7 @@ func (c *Client) URI(contractAddress string, tokenID *big.Int, tokenURI string) 
 	return tokenURI, nil
 }
 
-func (c *Client) Metadata(tokenURI string) ([]byte, error) {
+func (c *Client) Metadata(ctx context.Context, tokenURI string) ([]byte, error) {
 	if strings.Contains(tokenURI, ";base64,") {
 		contents := strings.Split(tokenURI, ";base64,")
 
@@ -386,9 +386,17 @@ func (c *Client) Metadata(tokenURI string) ([]byte, error) {
 	if strings.HasPrefix(tokenURI, "ipfs://") {
 		tokenURI = strings.Replace(tokenURI, "ipfs://", "https://ipfs.rss3.page/ipfs/", 1)
 	}
-	response, err := http.Get(tokenURI)
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, tokenURI, nil)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("new request: %w", err)
+	}
+
+	request.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36")
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("do request: %w", err)
 	}
 
 	defer func() {

--- a/internal/token/token_erc1155.go
+++ b/internal/token/token_erc1155.go
@@ -43,7 +43,7 @@ func (c *Client) ERC1155(context context.Context, network, contractAddress strin
 			return nil, err
 		}
 
-		result.Metadata, err = c.Metadata(result.URI)
+		result.Metadata, err = c.Metadata(context, result.URI)
 		if err != nil {
 			loggerx.Global().Named(contractAddress).Warn("Get ERC1155 Metadata error", zap.Error(err))
 		}

--- a/internal/token/token_erc721.go
+++ b/internal/token/token_erc721.go
@@ -70,7 +70,7 @@ func (c *Client) ERC721(ctx context.Context, network, contractAddress string, to
 			return nil, err
 		}
 
-		if result.Metadata, err = c.Metadata(result.URI); err != nil {
+		if result.Metadata, err = c.Metadata(ctx, result.URI); err != nil {
 			loggerx.Global().Named(contractAddress).Warn("Get NFT Metadata error", zap.Error(err))
 		}
 	}
@@ -160,7 +160,7 @@ func (c *Client) ERC721Zora(ctx context.Context, network string, tokenID *big.In
 		return nil, err
 	}
 
-	result.Metadata, err = c.Metadata(result.URI)
+	result.Metadata, err = c.Metadata(ctx, result.URI)
 	if err != nil {
 		return nil, err
 	}

--- a/service/indexer/internal/worker/collectible/marketplace/worker.go
+++ b/service/indexer/internal/worker/collectible/marketplace/worker.go
@@ -259,5 +259,7 @@ func (i *internal) Jobs() []worker.Job {
 }
 
 func New() worker.Worker {
-	return &internal{}
+	return &internal{
+		tokenClient: token.New(),
+	}
 }

--- a/service/indexer/internal/worker/collectible/poap/worker.go
+++ b/service/indexer/internal/worker/collectible/poap/worker.go
@@ -166,5 +166,7 @@ func (s *service) Jobs() []worker.Job {
 }
 
 func New() worker.Worker {
-	return &service{}
+	return &service{
+		tokenClient: token.New(),
+	}
 }

--- a/service/indexer/internal/worker/exchange/swap/worker.go
+++ b/service/indexer/internal/worker/exchange/swap/worker.go
@@ -296,7 +296,8 @@ func (s *service) Jobs() []worker.Job {
 
 func New(employer *shedlock.Employer) (worker.Worker, error) {
 	svc := service{
-		employer: employer,
+		employer:    employer,
+		tokenClient: token.New(),
 	}
 	return &svc, nil
 }


### PR DESCRIPTION
- add request header to avoid 403 forbidden when fetch nft metadata with valid ipfs url

https://pregod.rss3.dev/v1/notes/0xab90ddde2cf6a4753106a058acb4cc7412a58ae7?hash=0x27ed7327c867e5fc5bb8289319b12a47a1f6ad52475f08dc46f677884677973e

```
       "metadata": {
         "id": "35202",
-        "name": "SuperRare",
+        "name": "Circles Of Life ",
+        "image": "https://ipfs.pixura.io/ipfs/QmNd1BBY5iE9yYL2mEYqpZwPpVyot4Wi8TSX8m6RzQsXg3/ezgif.com-gif-maker17.gif",
         "value": "1",
         "symbol": "SUPR",
         "standard": "ERC-721",
         "collection": "SuperRare",
+        "description": "Modern Renaissance - Circles Of Life ",
         "value_display": "1",
         "contract_address": "0xb932a70a57673d89f4acffbe830e8ed7f75fb9e0"
       }
```