### PR TITLE
feat: optmize for mask

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
       - id: check-yaml
         args: ['--allow-multiple-documents']
   - repo: https://github.com/golangci/golangci-lint
-    rev: v1.50.1
+    rev: v1.51.2
     hooks:
       - id: golangci-lint
   - repo: https://github.com/commitizen-tools/commitizen

--- a/common/protocol/constant.go
+++ b/common/protocol/constant.go
@@ -16,6 +16,8 @@ const (
 	ExchangeRefresh = "pregod11.refresh"
 
 	IndexVirtual int64 = -1
+
+	LATEST_TX_HASH_KEY = "latest_tx_hash"
 )
 
 var WorkQ2RoutingKey = map[string]string{

--- a/deploy/prod/deploy-crawler-social.yaml
+++ b/deploy/prod/deploy-crawler-social.yaml
@@ -24,7 +24,7 @@ spec:
                 name: pregod-1-1
           env:
             - name: ENABLE_MIGRATION
-              value: "true"
+              value: "false"
           command:
             - crawler
             - --socialdb=social

--- a/go.mod
+++ b/go.mod
@@ -26,9 +26,12 @@ require (
 	github.com/labstack/echo-contrib v0.13.1
 	github.com/labstack/echo/v4 v4.10.0
 	github.com/lib/pq v1.10.7
+	github.com/naturalselectionlabs/kurora v0.25.3
+	github.com/naturalselectionlabs/kurora/client v0.0.0-20230214054219-dc2d1ee12a8d
 	github.com/rabbitmq/amqp091-go v1.6.1
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/samber/lo v1.37.0
+	github.com/scylladb/go-set v1.0.2
 	github.com/shopspring/decimal v1.3.1
 	github.com/shurcooL/graphql v0.0.0-20220606043923-3cf50f8a0a29
 	github.com/sirupsen/logrus v1.9.0
@@ -56,6 +59,7 @@ require (
 	github.com/Zilliqa/gozilliqa-sdk v1.2.0 // indirect
 	github.com/andres-erbsen/clock v0.0.0-20160526145045-9e14626cd129 // indirect
 	github.com/btcsuite/btcd/btcec/v2 v2.3.0 // indirect
+	github.com/btcsuite/btcd/chaincfg/chainhash v1.0.2 // indirect
 	github.com/cespare/cp v1.1.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
@@ -100,8 +104,6 @@ require (
 	github.com/multiformats/go-multibase v0.1.1 // indirect
 	github.com/multiformats/go-multihash v0.2.0 // indirect
 	github.com/multiformats/go-varint v0.0.6 // indirect
-	github.com/naturalselectionlabs/kurora v0.25.3 // indirect
-	github.com/naturalselectionlabs/kurora/client v0.0.0-20230214054219-dc2d1ee12a8d // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.5 // indirect
 	github.com/pkg/errors v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -116,6 +116,7 @@ github.com/btcsuite/btcd/btcec/v2 v2.3.0 h1:S/6K1GEwlEsFzZP4cOOl5mg6PEd/pr0zz7hv
 github.com/btcsuite/btcd/btcec/v2 v2.3.0/go.mod h1:zYzJ8etWJQIv1Ogk7OzpWjowwOdXY1W/17j2MW85J04=
 github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1/go.mod h1:7SFka0XMvUgj3hfZtydOrQY2mwhPclbT2snogU7SQQc=
 github.com/btcsuite/btcd/chaincfg/chainhash v1.0.2 h1:KdUfX2zKommPRa+PD0sWZUyXe9w277ABlgELO7H04IM=
+github.com/btcsuite/btcd/chaincfg/chainhash v1.0.2/go.mod h1:7SFka0XMvUgj3hfZtydOrQY2mwhPclbT2snogU7SQQc=
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f/go.mod h1:TdznJufoqS23FtqVCzL0ZqgP5MqXbb4fg/WgDys70nA=
 github.com/btcsuite/btcutil v0.0.0-20190207003914-4c204d697803/go.mod h1:+5NJ2+qvTyV9exUAL/rxXi3DcLg2Ts+ymUAY5y4NvMg=
 github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d/go.mod h1:+5NJ2+qvTyV9exUAL/rxXi3DcLg2Ts+ymUAY5y4NvMg=
@@ -197,6 +198,8 @@ github.com/ethereum/go-ethereum v1.10.26 h1:i/7d9RBBwiXCEuyduBQzJw/mKmnvzsN14jqB
 github.com/ethereum/go-ethereum v1.10.26/go.mod h1:EYFyF19u3ezGLD4RqOkLq+ZCXzYbLoNDdZlMt7kyKFg=
 github.com/fatih/color v1.3.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/fatih/set v0.2.1 h1:nn2CaJyknWE/6txyUDGwysr3G5QC6xWB/PtVjPBbeaA=
+github.com/fatih/set v0.2.1/go.mod h1:+RKtMCH+favT2+3YecHGxcc0b4KyVWA1QWWJUs4E0CI=
 github.com/fjl/gencodec v0.0.0-20220412091415-8bb9e558978c/go.mod h1:AzA8Lj6YtixmJWL+wkKoBGsLWy9gFrAzi4g+5bCKwpY=
 github.com/fjl/memsize v0.0.0-20180418122429-ca190fb6ffbc/go.mod h1:VvhXpOYNQvB+uIk2RvXzuaQtkQJzzIx6lSBe1xv7hi0=
 github.com/fjl/memsize v0.0.0-20190710130421-bcb5799ab5e5 h1:FtmdgXiUlNeRsoNMFlKLDt+S+6hbjVMEW6RGQ7aUf7c=
@@ -552,16 +555,8 @@ github.com/multiformats/go-varint v0.0.6/go.mod h1:3Ls8CIEsrijN6+B7PbrXRPxHRPuXS
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/naoina/go-stringutil v0.1.0/go.mod h1:XJ2SJL9jCtBh+P9q5btrd/Ylo8XwT/h1USek5+NqSA0=
 github.com/naoina/toml v0.1.2-0.20170918210437-9fafd6967416/go.mod h1:NBIhNtsFMo3G2szEBne+bO4gS192HuIYRqfvOWb4i1E=
-github.com/naturalselectionlabs/kurora v0.25.2 h1:8go97z3pDC6nHKtEQLckMyvPw2sOL5mbBwxyQQa4h84=
-github.com/naturalselectionlabs/kurora v0.25.2/go.mod h1:Rjo2lDB/t+T9aZrFcHN1VM+YZc/1QgequEFZqUpgGhs=
 github.com/naturalselectionlabs/kurora v0.25.3 h1:ogUh4+ifwgr8y52srLOd1gNgk39J35+Qrp2YbBZmbdg=
 github.com/naturalselectionlabs/kurora v0.25.3/go.mod h1:Rjo2lDB/t+T9aZrFcHN1VM+YZc/1QgequEFZqUpgGhs=
-github.com/naturalselectionlabs/kurora v0.25.4 h1:/P1RMo2gg6tES0KRskcaM8UT2D14iso52DjBZFc22MY=
-github.com/naturalselectionlabs/kurora v0.25.4/go.mod h1:Rjo2lDB/t+T9aZrFcHN1VM+YZc/1QgequEFZqUpgGhs=
-github.com/naturalselectionlabs/kurora/client v0.0.0-20230208132702-298e7ca82b36 h1:6kKM06Gni5etfW1vBv+iwuz4JzAgIb+maqC5ptjVn2Y=
-github.com/naturalselectionlabs/kurora/client v0.0.0-20230208132702-298e7ca82b36/go.mod h1:l2XVJ0tRgAfox3atwg029y6ctrVr3K+87XjH0mAefAE=
-github.com/naturalselectionlabs/kurora/client v0.0.0-20230213171304-129511988aa1 h1:U39vU7ochsL/1bzz8Jt0iQDR85r4N1uQGBDBEiy0thY=
-github.com/naturalselectionlabs/kurora/client v0.0.0-20230213171304-129511988aa1/go.mod h1:AUjJGozBbVsLiwaJKeE9SzMeKk5HXwoe9dhkajVg75o=
 github.com/naturalselectionlabs/kurora/client v0.0.0-20230214054219-dc2d1ee12a8d h1:kkNgbD70ZshjUiCAPIL37Vq4zg58PmLApakPxkxPr3s=
 github.com/naturalselectionlabs/kurora/client v0.0.0-20230214054219-dc2d1ee12a8d/go.mod h1:AUjJGozBbVsLiwaJKeE9SzMeKk5HXwoe9dhkajVg75o=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
@@ -635,6 +630,8 @@ github.com/rs/xhandler v0.0.0-20160618193221-ed27b6fd6521/go.mod h1:RvLn4FgxWubr
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/scylladb/go-set v1.0.2 h1:SkvlMCKhP0wyyct6j+0IHJkBkSZL+TDzZ4E7f7BCcRE=
+github.com/scylladb/go-set v1.0.2/go.mod h1:DkpGd78rljTxKAnTDPFqXSGxvETQnJyuSOQwsHycqfs=
 github.com/segmentio/kafka-go v0.1.0/go.mod h1:X6itGqS9L4jDletMsxZ7Dz+JFWxM6JHfPOCvTvk+EJo=
 github.com/segmentio/kafka-go v0.2.0/go.mod h1:X6itGqS9L4jDletMsxZ7Dz+JFWxM6JHfPOCvTvk+EJo=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=

--- a/service/crawler/cmd/main.go
+++ b/service/crawler/cmd/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"strings"
 
+	"github.com/naturalselectionlabs/pregod/common/database"
 	"github.com/naturalselectionlabs/pregod/common/protocol"
 	"github.com/naturalselectionlabs/pregod/service/crawler/internal/config"
 	"github.com/naturalselectionlabs/pregod/service/crawler/internal/server"
@@ -56,6 +57,7 @@ func main() {
 		socialRedisDB, _ := rootCommand.Flags().GetInt("socialredisdb")
 		if socialRedisDB != -1 {
 			configCrawler.Redis.DB = socialRedisDB
+			database.SetLatestTx(false)
 		}
 
 		return srv.Run()

--- a/service/hub/internal/server/dao/note.go
+++ b/service/hub/internal/server/dao/note.go
@@ -2,11 +2,15 @@ package dao
 
 import (
 	"context"
+	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/lib/pq"
+	"github.com/naturalselectionlabs/pregod/common/cache"
 	"github.com/naturalselectionlabs/pregod/common/database"
 	dbModel "github.com/naturalselectionlabs/pregod/common/database/model"
+	"github.com/naturalselectionlabs/pregod/common/protocol"
 	"github.com/naturalselectionlabs/pregod/common/protocol/filter"
 	"github.com/naturalselectionlabs/pregod/service/hub/internal/server/model"
 	"go.opentelemetry.io/otel"
@@ -87,6 +91,49 @@ func BatchGetTransactions(ctx context.Context, request model.BatchGetNotesReques
 
 	transactions := make([]dbModel.Transaction, 0)
 	total := int64(0)
+	usedRedis := false
+
+	// 针对 mask 常来刷新的特殊优化，从 redis 里面取最新的 Limit 条 hash，而不是用 owner in
+	//  redis 操作失败时，从数据库取
+	// （从数据库取是没问题的，但几十个这样的并发 SQL 会导致每句都超过 60s）
+	if database.IsMaskReq(request.Tag, request.Type, request.Network, request.Platform) {
+		failed := false
+
+		allTx := []struct {
+			Hash      string
+			Timestamp int64
+		}{}
+
+		for _, v := range request.Address {
+			key := strings.Join([]string{protocol.LATEST_TX_HASH_KEY, v}, ":")
+
+			hashAndTS, err := cache.Global().ZRevRange(ctx, key, 0, int64(request.Limit-1)).Result()
+			if err != nil {
+				failed = true
+				break
+			}
+			for index, v := range hashAndTS {
+				if index%2 == 0 { // hash
+					allTx = append(allTx, struct {
+						Hash      string
+						Timestamp int64
+					}{Hash: v})
+				} else { // timestamp
+					allTx[len(allTx)-1].Timestamp, _ = strconv.ParseInt(v, 10, 64)
+				}
+			}
+		}
+		if !failed {
+			sort.SliceStable(allTx, func(i, j int) bool {
+				return allTx[i].Timestamp > allTx[j].Timestamp
+			})
+			latestTx := allTx[:request.Limit]
+			if err := database.Global().Where("hash IN ?", latestTx).Find(&transactions).Error; err != nil {
+				return nil, 0, err
+			}
+			usedRedis = true
+		}
+	}
 
 	sql := database.Global().
 		Model(&dbModel.Transaction{}).
@@ -135,8 +182,14 @@ func BatchGetTransactions(ctx context.Context, request model.BatchGetNotesReques
 		sql = sql.Where("timestamp > ?", request.Timestamp)
 	}
 
-	if err := sql.Count(&total).Limit(request.Limit).Offset(request.Page * request.Limit).Order("timestamp DESC, index DESC").Find(&transactions).Error; err != nil {
-		return nil, 0, err
+	if usedRedis { // only need total
+		if err := sql.Count(&total).Error; err != nil {
+			return nil, 0, err
+		}
+	} else { // default
+		if err := sql.Count(&total).Limit(request.Limit).Offset(request.Page * request.Limit).Order("timestamp DESC, index DESC").Find(&transactions).Error; err != nil {
+			return nil, 0, err
+		}
 	}
 
 	return transactions, total, nil

--- a/service/indexer/internal/server/server.go
+++ b/service/indexer/internal/server/server.go
@@ -696,7 +696,12 @@ func (s *Server) handleWorkers(ctx context.Context, message *protocol.Message, t
 		}
 	}
 
-	return s.upsertTransactions(ctx, message, tx, result)
+	res := s.upsertTransactions(ctx, message, tx, result)
+
+	// 这里出错不影响主流程，因此不 return
+	_ = database.SaveLatestTxHashByAddress(ctx, message.Address)
+
+	return res
 }
 
 func (s *Server) upsertAddress(ctx context.Context, address model.Address) {


### PR DESCRIPTION
这个 PR 的改动：

1. indexer 和 crawler 在 upsert 完一个人的数据，就会取它的最新 500 条 hash （mask 条件）带时间戳放 redis 里
2. 请求到 hub，如果是 mask 的条件，直接从 redis 取 limit 条 hash，然后进行下一步

> 已经在本地测试了一些能想到的读写的边缘情况，表现正常

---


发布以后的状况：
1. 会先发布 indexer 让 mask 需要的地址数据被写入 redis，一段时间后再发布 hub，此时观察从 transaction 表取数据的这个操作应该会少很多
2. 如果来请求一个新地址，第一次里面没数据，响应空的（和现状一样）；第二次就会有数据（indexer 写数据到 redis 了，和现状一样）

---

线上发布流程：
1. build 完镜像，不自动部署，手动部署 indexer
    - mask 请求一轮在十分钟内，十分钟以后他们需要的地址都会存在 redis key；此时观察 redis 不够的话就扩容
3. 等一段时间，发布其余的