### PR TITLE
fix: zora reflect panic

### DIFF
--- a/internal/token/token_erc721.go
+++ b/internal/token/token_erc721.go
@@ -156,13 +156,15 @@ func (c *Client) ERC721Zora(ctx context.Context, network string, tokenID *big.In
 		return nil, err
 	}
 
-	if result.URI, err = zoraContract.TokenMetadataURI(&bind.CallOpts{}, tokenID); err != nil {
-		return nil, err
-	}
+	if tokenID != nil {
+		if result.URI, err = zoraContract.TokenMetadataURI(&bind.CallOpts{}, tokenID); err != nil {
+			return nil, err
+		}
 
-	result.Metadata, err = c.Metadata(ctx, result.URI)
-	if err != nil {
-		return nil, err
+		result.Metadata, err = c.Metadata(ctx, result.URI)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	var metadata Metadata


### PR DESCRIPTION
https://k8s.kindjeff.com/?gacxx33tkbdgdpyjv52vxtjgtq=qzqz3ni36pq2fpgs77h4vk432y#/log/pregod/pregod-1-1-indexer-65c4f79699-fdjkd/pod?namespace=pregod&container=pregod-1-1
```
panic: reflect: call of reflect.Value.Type on zero Value
goroutine 42726 [running]:
go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End.func1()
 /go/pkg/mod/go.opentelemetry.io/otel/sdk@v1.13.0/trace/span.go:383 +0x2a
go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End(0xc002663200, {0x0, 0x0, 0x4a194749e45ca10a?})
 /go/pkg/mod/go.opentelemetry.io/otel/sdk@v1.13.0/trace/span.go:421 +0x93b
panic({0x10a4800, 0xc008d75f68})
 /usr/local/go/src/runtime/panic.go:838 +0x207
reflect.Value.Type({0x0?, 0x0?, 0xc00396c398?})
 /usr/local/go/src/reflect/value.go:2453 +0x12e
github.com/ethereum/go-ethereum/accounts/abi.indirect({0x123dc80?, 0x0?, 0x7f2d39a311d8?})
 /go/pkg/mod/github.com/ethereum/go-ethereum@v1.10.26/accounts/abi/reflect.go:53 +0x4f
github.com/ethereum/go-ethereum/accounts/abi.Type.pack({0x0, 0x100, 0x1, {0xc00276add7, 0x7}, {0x0, 0x0}, {0x0, 0x0, 0x0}, ...}, ...)
 /go/pkg/mod/github.com/ethereum/go-ethereum@v1.10.26/accounts/abi/type.go:269 +0x3e
github.com/ethereum/go-ethereum/accounts/abi.Arguments.Pack({0xc004082480, 0x1, 0xc00af27980?}, {0xc00396d708?, 0x1, 0x0?})
 /go/pkg/mod/github.com/ethereum/go-ethereum@v1.10.26/accounts/abi/argument.go:241 +0x365
github.com/ethereum/go-ethereum/accounts/abi.ABI.Pack({{{0x0, 0x0}, {0x0, 0x0}, 0x0, {0xc0008b3230, 0xa}, 0x0, 0x0, {0xc0038f6fc0, ...}, ...}, ...}, ...)
 /go/pkg/mod/github.com/ethereum/go-ethereum@v1.10.26/accounts/abi/abi.go:76 +0x1b0
github.com/ethereum/go-ethereum/accounts/abi/bind.(*BoundContract).Call(0xc0038e2c80, 0xe192ad?, 0x1059700?, {0x1273b34, 0x10}, {0xc00396d708?, 0x6?, 0x0?})
 /go/pkg/mod/github.com/ethereum/go-ethereum@v1.10.26/accounts/abi/bind/base.go:158 +0x10f
github.com/naturalselectionlabs/pregod/common/datasource/ethereum/contract/erc721/zora.(*ZoraCaller).TokenMetadataURI(0xc00321d200?, 0x2a?, 0x2a?)
 /rss3-pregod/common/datasource/ethereum/contract/erc721/zora/zora.go:788 +0x65
github.com/naturalselectionlabs/pregod/internal/token.(*Client).ERC721Zora(0xc00321c240?, {0x1544c80, 0xc00e40a180}, {0xc0019af8c8?, 0x494ba950f1b87e51?}, 0x0)
 /rss3-pregod/internal/token/token_erc721.go:159 +0x278
github.com/naturalselectionlabs/pregod/internal/token.(*Client).ERC721(0xc00396dd48?, {0x1544c80, 0xc00e40a180}, {0xc0019af8c8, 0x8}, {0xc00321c240, 0x2a}, 0x0)
 /rss3-pregod/internal/token/token_erc721.go:33 +0x225
github.com/naturalselectionlabs/pregod/internal/token.(*Client).NFT(0xc9db34?, {0x1544c80, 0xc00e40a180}, {0xc0019af8c8, 0x8}, {0xc00321c240, 0x2a}, 0x0?)
 /rss3-pregod/internal/token/token.go:237 +0x65
github.com/naturalselectionlabs/pregod/internal/token.(*Client).NFTToMetadata(0xc000273080?, {0x1544c80?, 0xc00e40a180?}, {0xc0019af8c8?, 0x2f?}, {0xc00321c240?, 0x0?}, 0x0?)
 /rss3-pregod/internal/token/token.go:251 +0x4e
github.com/naturalselectionlabs/pregod/service/indexer/internal/worker/transaction.(*service).buildEthereumTokenApprovalMetadata(_, {_, _}, {0xe0c9d3, {0x0, 0xeda08c3a0, 0x1cbea40}, {0xc00286c780, 0x42}, 0x0, ...}, ...)
 /rss3-pregod/service/indexer/internal/worker/transaction/worker.go:642 +0x7c5
github.com/naturalselectionlabs/pregod/service/indexer/internal/worker/transaction.(*service).handleEthereumOriginToken(_, {_, _}, _, {0xe0c9d3, {0x0, 0xeda08c3a0, 0x1cbea40}, {0xc00286c780, 0x42}, ...}, ...)
 /rss3-pregod/service/indexer/internal/worker/transaction/worker.go:390 +0x142f
github.com/naturalselectionlabs/pregod/service/indexer/internal/worker/transaction.(*service).handleEthereumOrigin.func1({{0xc00286c780, 0x42}, {0x0, 0xeda08c3a0, 0x1cbea40}, 0x0, {0x0, 0x0}, {0x0, 0x0}, ...})
 /rss3-pregod/service/indexer/internal/worker/transaction/worker.go:173 +0x21e
created by github.com/naturalselectionlabs/pregod/service/indexer/internal/worker/transaction.(*service).handleEthereumOrigin
 /rss3-pregod/service/indexer/internal/worker/transaction/worker.go:158 +0x90c
```