### PR TITLE
feature(hub): add more error code definition and handling

### DIFF
--- a/service/hub/internal/server/handler/error.go
+++ b/service/hub/internal/server/handler/error.go
@@ -89,6 +89,7 @@ func ErrorFunc(err error, c echo.Context) {
 	}
 
 	_ = c.JSON(httpCode, &ErrorResponse{
-		Error: strings.ToLower(errorMessage),
+		Error:     strings.ToLower(errorMessage),
+		ErrorCode: ErrorCodeBadRequest,
 	})
 }

--- a/service/hub/internal/server/middlewarex/apiHandleMiddleware.go
+++ b/service/hub/internal/server/middlewarex/apiHandleMiddleware.go
@@ -18,8 +18,13 @@ import (
 )
 
 type ErrorResponse struct {
-	Error string `json:"error"`
+	Error     string `json:"error"`
+	ErrorCode int    `json:"error_code"`
 }
+
+const (
+	ErrorCodeAddressIsInvalid = 1005
+)
 
 func APIMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
@@ -27,7 +32,8 @@ func APIMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
 		if address != "" {
 			if address, err := ResolveAddress(c, address, false); err != nil {
 				return c.JSON(http.StatusOK, &ErrorResponse{
-					Error: err.Error(),
+					Error:     err.Error(),
+					ErrorCode: ErrorCodeAddressIsInvalid,
 				})
 			} else {
 				c.SetParamValues(address)


### PR DESCRIPTION
1. Added some error code definitions for better front-end display

```go
const (
	ErrorCodeBadRequest                = 1001
	ErrorCodeValidateFailed            = 1002
	ErrorCodeBadParams                 = 1003
	ErrorCodeAddressIsEmpty            = 1004
	ErrorCodeAddressIsInvalid          = 1005
	ErrorCodeInternalError             = 1006
	ErrorCodeNotSupportContract        = 1007
	ErrorCodeGetTransactionByHashError = 1008
	ErrorCodeKeyAlreadyExists          = 1009
	ErrorCodeSigToPubError             = 1010
	ErrorCodeAddressIsNotMatch         = 1011
	ErrorCodeInvalidExchangeType       = 1012
)
```

2. Current response struct `ErrorResponse` def is modified

```go
type ErrorResponse struct {
	Error     string `json:"error"`
	ErrorCode int    `json:"error_code"`
}
```

For example, response of request `/tx/xxx` is

```json
{"error":"record not found","error_code":1008}
```