### PR TITLE
fix: addresses count beat

### DIFF
--- a/service/beat/cmd/main.go
+++ b/service/beat/cmd/main.go
@@ -37,17 +37,13 @@ const (
 						FROM pg_class
 						WHERE relname = 'transfers';`
 
-	addressesCountSQL = `SELECT reltuples::bigint AS total
-							FROM pg_class
-							WHERE relname = 'address';`
+	addressesCountSQL = `SELECT count(*) FROM address;`
 
 	transfersPerTagSQL = `SELECT tag, COUNT(*)
 							FROM (SELECT tag FROM transfers ORDER BY updated_at DESC LIMIT 100000) AS temp
 							GROUP BY tag;`
 
-	profilesCountSQL = `SELECT reltuples::bigint AS total
-								FROM pg_class
-								WHERE relname = 'profiles';`
+	profilesCountSQL = `SELECT count(*) FROM profiles;`
 
 	profilesPerPlatformSQL = `SELECT platform, count(1) AS count
 						FROM dataset_domains.domains


### PR DESCRIPTION
- address / profiles / notes 三个东西的总数统计用了 `SELECT reltuples::bigint FROM pg_class`。打点数据看到其中 address 数据飘忽不定，波动非常大
    - 看了最近 30 天一共六百多次统计，profiles 和 notes 的数据还是比较准确的
- address 和 profiles 现在总数不到一百万行，执行 `count(*)` 三秒左右能行，所以就这么做了；notes 总数三亿+行，即使是抽样也很大而且引入的波动会比现在更大，暂时只能这样